### PR TITLE
fix aqualinkd#78: PDA Init :- wait for next menu failed from ballle98

### DIFF
--- a/source/config.c
+++ b/source/config.c
@@ -608,6 +608,12 @@ void init_parameters (struct aqconfig * parms)
   _cfgParams[_numCfgParams].value_type = CFG_BOOL;
   _cfgParams[_numCfgParams].name = CFG_N_pda_sleep_mode;
   _cfgParams[_numCfgParams].default_value = (void *)&_dcfg_true;
+
+  _numCfgParams++;
+  _cfgParams[_numCfgParams].value_ptr = &_aqconfig_.pda_bypass_info;
+  _cfgParams[_numCfgParams].value_type = CFG_BOOL;
+  _cfgParams[_numCfgParams].name = "pda_bypass_info";
+  _cfgParams[_numCfgParams].default_value = (void *)&_dcfg_false;
 #endif
 
   //#endif

--- a/source/config.h
+++ b/source/config.h
@@ -78,6 +78,7 @@ struct aqconfig
   bool override_freeze_protect;
   #ifdef AQ_PDA
   bool pda_sleep_mode;
+  bool pda_bypass_info;
   #endif
   bool convert_mqtt_temp;
   bool convert_dz_temp;

--- a/source/json_messages.c
+++ b/source/json_messages.c
@@ -346,7 +346,7 @@ int build_device_JSON(struct aqualinkdata *aqdata, char* buffer, int size, bool 
     length += sprintf(buffer+length, ",\"temp_units\":\"%s\"",JSON_UNKNOWN );
 
   length += sprintf(buffer+length,  ", \"devices\": [");
-  
+
   for (i=0; i < aqdata->total_buttons; i++) 
   {
     if ( strcmp(BTN_POOL_HTR,aqdata->aqbuttons[i].name) == 0 && (ENABLE_HEATERS || aqdata->pool_htr_set_point != TEMP_UNKNOWN)) {

--- a/source/pda_aq_programmer.c
+++ b/source/pda_aq_programmer.c
@@ -754,7 +754,11 @@ void *set_aqualink_PDA_init( void *ptr )
     //printf("****** Version '%s' ********\n",aq_data->version);
     LOG(PDA_LOG,LOG_DEBUG, "PDA type=%d, version=%s\n", _PDA_Type, aq_data->version);
     // don't wait for version menu to time out press back to get to home menu faster
-    //send_pda_cmd(KEY_PDA_BACK);
+    #if AQ_PDA
+      if (_aqconfig_.pda_bypass_info) {
+        send_pda_cmd(KEY_PDA_BACK);
+      }
+    #endif
     //if (! waitForPDAnextMenu(aq_data)) { // waitForPDAnextMenu waits for highlight chars, which we don't get on normal menu
     
     if (! waitForPDAMessageType(aq_data,CMD_PDA_CLEAR,10)) {


### PR DESCRIPTION
During boot on PDA-PSS6, the initial menu detection failed as reported by ballle98. This is a port from ballle98 patch to latest code base.