### PR TITLE
Fix for PDA with Pool Heater/Spa Heater at any button

### DIFF
--- a/source/aq_panel.c
+++ b/source/aq_panel.c
@@ -1039,7 +1039,16 @@ void initPanelButtons(struct aqualinkdata *aqdata, bool rs, int size, bool combo
     aqdata->pool_heater_index = index-3;
     aqdata->spa_heater_index = index-2;
     aqdata->solar_heater_index = index-1;
-
+    if (_aqconfig_.pda_force_pool_heater_btn != 0 && _aqconfig_.pda_force_pool_heater_btn < aqdata->total_buttons) {
+      aqdata->pool_heater_index = _aqconfig_.pda_force_pool_heater_btn;
+    }
+    if (_aqconfig_.pda_force_spa_heater_btn != 0 && _aqconfig_.pda_force_spa_heater_btn < aqdata->total_buttons) {
+      aqdata->spa_heater_index = _aqconfig_.pda_force_spa_heater_btn;
+    }
+    if (_aqconfig_.pda_force_solar_heater_btn != 0 && _aqconfig_.pda_force_solar_heater_btn < aqdata->total_buttons) {
+      aqdata->solar_heater_index = _aqconfig_.pda_force_solar_heater_btn;
+    }
+    
     // Reset all LED's to off since their is no off state in PDA.
     for(int i=0; i < aqdata->total_buttons; i++) {
         aqdata->aqbuttons[i].led->state = OFF;

--- a/source/config.c
+++ b/source/config.c
@@ -922,6 +922,12 @@ char *generate_mqtt_id(char *buf, int len) {
   return buf;
 }
 
+void swapConfigButtonName(aqkey *btn1, aqkey *btn2)
+{
+  char *name = btn1->name;
+  btn1->name = btn2->name;
+  btn2->name = name;
+}
 
 bool setConfigValue(struct aqualinkdata *aqdata, char *param, char *value) {
   bool rtn = false;
@@ -1296,7 +1302,37 @@ if (strlen(cleanwhitespace(value)) <= 0) {
       LOG(AQUA_LOG,LOG_ERR, "Config error, blank value for `%s`\n",param);
       rtn = false;
     }
-
+ #if AQ_PDA
+  } else if (strncasecmp(param, "pda_force_pool_heater_btn", 25) == 0) {
+    int num = strtoul(cleanwhitespace(value), NULL, 10) - 1;
+    if (num < 0 || num >= aqdata->total_buttons) {
+      LOG(AQUA_LOG,LOG_ERR, "%s must be index of available button", param);
+      rtn=false;
+    } else {
+      swapConfigButtonName(&aqdata->aqbuttons[aqdata->pool_heater_index], &aqdata->aqbuttons[num]);
+      aqdata->pool_heater_index = num;
+      rtn=true;
+    }
+  } else if (strncasecmp(param, "pda_force_spa_heater_btn", 24) == 0) {
+    int num = strtoul(cleanwhitespace(value), NULL, 10) - 1;
+    if (num < 0 || num >= aqdata->total_buttons) {
+      LOG(AQUA_LOG,LOG_ERR, "%s must be index of available button", param);
+      rtn=false;
+    } else {
+      swapConfigButtonName(&aqdata->aqbuttons[aqdata->spa_heater_index], &aqdata->aqbuttons[num]);
+      aqdata->spa_heater_index = num;
+      rtn=true;
+    }
+  } else if (strncasecmp(param, "pda_force_solar_heater_btn", 26) == 0) {
+    int num = strtoul(cleanwhitespace(value), NULL, 10) - 1;
+    if (num < 0 || num >= aqdata->total_buttons) {
+      LOG(AQUA_LOG,LOG_ERR, "%s must be index of available button", param);
+      rtn=false;
+    } else {
+      aqdata->solar_heater_index = num;
+      rtn=true;
+    }
+ #endif
   }
 //#endif
 

--- a/source/config.h
+++ b/source/config.h
@@ -78,6 +78,10 @@ struct aqconfig
   bool override_freeze_protect;
   #ifdef AQ_PDA
   bool pda_sleep_mode;
+  bool pda_bypass_info;
+  int pda_force_pool_heater_btn;
+  int pda_force_spa_heater_btn;
+  int pda_force_solar_heater_btn;
   #endif
   bool convert_mqtt_temp;
   bool convert_dz_temp;

--- a/source/pda_aq_programmer.c
+++ b/source/pda_aq_programmer.c
@@ -677,6 +677,26 @@ void *set_aqualink_PDA_device_on_off( void *ptr )
                              aq_data->aqbuttons[device].label);
               }
           }
+      } if (strcasestr(device_name, "LIGHT") != NULL) {
+	  if (state == ON) {
+            // Set Light ON prompt for color selection
+	    if (!waitForPDAnextMenu(aq_data)) {
+	      LOG(PDA_LOG,LOG_ERR, "PDA Device On/Off: %s on - waitForPDAnextMenu\n",
+	  	       aq_data->aqbuttons[device].label);
+	    } else {
+	      send_pda_cmd(KEY_PDA_SELECT);
+	      while (get_pda_queue_length() > 0) { delay(500); }
+	      if (!waitForPDAMessageType(aq_data,CMD_PDA_HIGHLIGHT,20)) {
+	          LOG(PDA_LOG,LOG_ERR, "PDA Device On/Off: %s on - wait for CMD_PDA_HIGHLIGHT\n",
+			     aq_data->aqbuttons[device].label);
+	      }
+	    }
+	  } else {
+	      if (!waitForPDAMessageType(aq_data,CMD_PDA_HIGHLIGHT,20)) {
+	          LOG(PDA_LOG,LOG_ERR, "PDA Device On/Off: %s on - wait for CMD_PDA_HIGHLIGHT\n",
+			     aq_data->aqbuttons[device].label);
+	      }
+	  }
       } else { // not turning on heater wait for line update
           // worst case spa when pool is running
           if (!waitForPDAMessageType(aq_data,CMD_MSG_LONG,2)) {


### PR DESCRIPTION
No every PDA panel wire the connection with the spa/pool button toward the end (like button 8 and 9). Some wires them at button 3 and 4. As such, support assigning spa/pool heater on any button.

To support this, parameter pda_force_*_heater is added to swap the button name accordingly.