### PR TITLE
Fix Homebridge report of undefined getCharacteristic

### DIFF
--- a/source/net_services.c
+++ b/source/net_services.c
@@ -915,7 +915,8 @@ void mqtt_broadcast_aqualinkstate(struct mg_connection *nc)
   for (i=0; i < _aqualink_data->total_buttons; i++) {
     if (_last_mqtt_aqualinkdata.aqualinkleds[i].state != _aqualink_data->aqbuttons[i].led->state) {
       _last_mqtt_aqualinkdata.aqualinkleds[i].state = _aqualink_data->aqbuttons[i].led->state;
-      if (_aqualink_data->aqbuttons[i].code == KEY_POOL_HTR || _aqualink_data->aqbuttons[i].code == KEY_SPA_HTR) {
+      if (strcmp(BTN_POOL_HTR,_aqualink_data->aqbuttons[i].name) == 0 ||
+          strcmp(BTN_SPA_HTR,_aqualink_data->aqbuttons[i].name) == 0) {
         send_mqtt_heater_state_msg(nc, _aqualink_data->aqbuttons[i].name, _aqualink_data->aqbuttons[i].led->state);
       } else {
         send_mqtt_state_msg(nc, _aqualink_data->aqbuttons[i].name, _aqualink_data->aqbuttons[i].led->state);


### PR DESCRIPTION
When switch pool/spa heater name using the config parameter pda_force_*_heater_btn, the name is now moved to another button. net_service generating MQTT message should use the name instead the equipment key code. Key code can get remapped to anything. Without this fix, Homebridge will not get Aux1/enabled topic.