### PR TITLE
Fix failure setting SWG percent

### DIFF
--- a/source/pda_aq_programmer.c
+++ b/source/pda_aq_programmer.c
@@ -44,7 +44,7 @@ bool waitForPDAMessageHighlight(struct aqualinkdata *aq_data, int highlighIndex,
 bool waitForPDAMessageType(struct aqualinkdata *aq_data, unsigned char mtype, int numMessageReceived);
 bool waitForPDAMessageTypes(struct aqualinkdata *aq_data, unsigned char mtype1, unsigned char mtype2, int numMessageReceived);
 bool waitForPDAMessageTypesOrMenu(struct aqualinkdata *aq_data, unsigned char mtype1, unsigned char mtype2, int numMessageReceived, char *text, int line);
-bool goto_pda_menu(struct aqualinkdata *aq_data, pda_menu_type menu);
+bool goto_pda_menu(struct aqualinkdata *aq_data, pda_menu_type menu, bool home_first);
 bool wait_pda_selected_item(struct aqualinkdata *aq_data);
 bool waitForPDAnextMenu(struct aqualinkdata *aq_data);
 bool loopover_devices(struct aqualinkdata *aq_data);
@@ -247,7 +247,7 @@ bool loopover_devices(struct aqualinkdata *aq_data) {
   int i;
   int index = -1;
 
-  if (! goto_pda_menu(aq_data, PM_EQUIPTMENT_CONTROL)) {
+  if (! goto_pda_menu(aq_data, PM_EQUIPTMENT_CONTROL, false)) {
     LOG(PDA_LOG,LOG_ERR, "loopover_devices :- can't goto PM_EQUIPTMENT_CONTROL menu\n");
     //cleanAndTerminateThread(threadCtrl);
     return false;
@@ -459,7 +459,7 @@ bool _select_pda_menu_item(struct aqualinkdata *aq_data, char *menuText, bool wa
 // and 6594 - AquaLink RS Control Panel Installation Manual
 // https://www.jandy.com/-/media/zodiac/global/downloads/0748-91071/6594.pdf
 
-bool goto_pda_menu(struct aqualinkdata *aq_data, pda_menu_type menu) {
+bool goto_pda_menu(struct aqualinkdata *aq_data, pda_menu_type menu, bool home_first) {
   bool ret = true;
   int cnt = 0;
 
@@ -475,7 +475,26 @@ bool goto_pda_menu(struct aqualinkdata *aq_data, pda_menu_type menu) {
       LOG(PDA_LOG,LOG_DEBUG, "goto_pda_menu building home menu\n");
       waitForPDAMessageType(aq_data,CMD_PDA_HIGHLIGHT,15);
   }
-  
+
+  if (home_first) {
+    //
+    // Before start, put back to home menu. Otherwise may get timing issue.
+    // We can be sending SELECT at EQUIPMNET menu while PDA immediate fall back to HOME
+    // menu. Also going back to HOME with first menu item highlighted seems to be
+    // more stable.
+    send_pda_cmd(KEY_PDA_BACK);
+    if (!waitForPDAnextMenu(aq_data)) {
+      LOG(PDA_LOG,LOG_ERR, "PDA goto menu: can't find HOME menu\n");
+      return false;
+    }
+    if (pda_m_type() == PM_HOME && pda_m_hlightindex() != 4) {
+      send_pda_cmd(KEY_PDA_BACK);
+      if (!waitForPDAnextMenu(aq_data)) {
+        LOG(PDA_LOG,LOG_ERR, "PDA goto menu: can't find HOME menu\n");
+        return false;
+      }
+    }
+  }
 
   while (ret && (pda_m_type() != menu) && cnt <= 5) {
     switch (menu) {
@@ -638,7 +657,7 @@ void *set_aqualink_PDA_device_on_off( void *ptr )
 
   LOG(PDA_LOG,LOG_INFO, "PDA Device On/Off, device '%s', state %d\n",aq_data->aqbuttons[device].label,state);
 
-  if (! goto_pda_menu(aq_data, PM_EQUIPTMENT_CONTROL)) {
+  if (! goto_pda_menu(aq_data, PM_EQUIPTMENT_CONTROL, true)) {
     LOG(PDA_LOG,LOG_ERR, "PDA Device On/Off :- can't find EQUIPTMENT CONTROL menu\n");
     cleanAndTerminateThread(threadCtrl);
     return ptr;
@@ -710,7 +729,7 @@ void *get_aqualink_PDA_device_status( void *ptr )
   
   waitForSingleThreadOrTerminate(threadCtrl, AQ_PDA_DEVICE_STATUS);
   
-  goto_pda_menu(aq_data, PM_HOME);
+  goto_pda_menu(aq_data, PM_HOME, false);
 
   if (! loopover_devices(aq_data)) {
     LOG(PDA_LOG,LOG_ERR, "PDA Device Status :- failed\n");
@@ -782,7 +801,7 @@ void *set_aqualink_PDA_init( void *ptr )
 
   pda_reset_sleep();
 
-  goto_pda_menu(aq_data, PM_HOME);
+  goto_pda_menu(aq_data, PM_HOME, false);
 
   cleanAndTerminateThread(threadCtrl);
 
@@ -819,7 +838,7 @@ void *set_aqualink_PDA_wakeinit( void *ptr )
 bool _get_PDA_freeze_protect_temp(struct aqualinkdata *aq_data) {
   
   if ( _PDA_Type == PDA) {
-    if (! goto_pda_menu(aq_data, PM_FREEZE_PROTECT)) {   
+    if (! goto_pda_menu(aq_data, PM_FREEZE_PROTECT, true)) {
       return false;
     }
     /* select the freeze protect temp to see which devices are enabled by freeze
@@ -833,12 +852,12 @@ bool _get_PDA_freeze_protect_temp(struct aqualinkdata *aq_data) {
 }
 
 bool _get_PDA_aqualink_pool_spa_heater_temps(struct aqualinkdata *aq_data) {
-  
+
    // Get heater setpoints
-  if (! goto_pda_menu(aq_data, PM_SET_TEMP)) {
+  if (! goto_pda_menu(aq_data, PM_SET_TEMP, true)) {
     LOG(PDA_LOG,LOG_ERR, "Could not get heater setpoints, trying again!\n");
     // Going to try this twice.
-    if (! goto_pda_menu(aq_data, PM_SET_TEMP)) {
+    if (! goto_pda_menu(aq_data, PM_SET_TEMP, false)) {
       return false;
     }
   }
@@ -1051,7 +1070,7 @@ void *set_PDA_aqualink_SWG_setpoint(void *ptr) {
   int val = atoi((char*)threadCtrl->thread_args);
   val = setpoint_check(SWG_SETPOINT, val, aq_data);
 
-  if (! goto_pda_menu(aq_data, PM_AQUAPURE)) {
+  if (! goto_pda_menu(aq_data, PM_AQUAPURE, true)) {
     LOG(PDA_LOG,LOG_ERR, "Error finding SWG setpoints menu\n");
     cleanAndTerminateThread(threadCtrl);
     return ptr;
@@ -1073,7 +1092,7 @@ void *set_PDA_aqualink_SWG_setpoint(void *ptr) {
   }
   
   waitfor_pda_queue2empty();
-  goto_pda_menu(aq_data, PM_HOME);
+  goto_pda_menu(aq_data, PM_HOME, false);
 
   cleanAndTerminateThread(threadCtrl);
   return ptr;
@@ -1090,7 +1109,7 @@ void *set_PDA_aqualink_boost(void *ptr)
 
   int val = atoi((char*)threadCtrl->thread_args);
 
-  if (! goto_pda_menu(aq_data, PM_BOOST)) {
+  if (! goto_pda_menu(aq_data, PM_BOOST, true)) {
     LOG(PDA_LOG,LOG_ERR, "Error finding BOOST menu\n");
     return false;
   }
@@ -1113,7 +1132,7 @@ void *set_PDA_aqualink_boost(void *ptr)
   }
 
   waitfor_pda_queue2empty();
-  goto_pda_menu(aq_data, PM_HOME);
+  goto_pda_menu(aq_data, PM_HOME, false);
   cleanAndTerminateThread(threadCtrl);
   return ptr;
 }
@@ -1148,7 +1167,7 @@ bool set_PDA_aqualink_heater_setpoint(struct aqualinkdata *aq_data, int val, boo
     return true;
   } 
 
-  if (! goto_pda_menu(aq_data, PM_SET_TEMP)) {
+  if (! goto_pda_menu(aq_data, PM_SET_TEMP, true)) {
     LOG(PDA_LOG,LOG_ERR, "Error finding heater setpoints menu\n");
     return false;
   }
@@ -1173,7 +1192,7 @@ void *set_aqualink_PDA_pool_heater_temps( void *ptr )
   set_PDA_aqualink_heater_setpoint(aq_data, val, true);
 
   waitfor_pda_queue2empty();
-  goto_pda_menu(aq_data, PM_HOME);
+  goto_pda_menu(aq_data, PM_HOME, false);
 
   cleanAndTerminateThread(threadCtrl);
   return ptr;
@@ -1193,7 +1212,7 @@ void *set_aqualink_PDA_spa_heater_temps( void *ptr )
   set_PDA_aqualink_heater_setpoint(aq_data, val, false);
   
   waitfor_pda_queue2empty();
-  goto_pda_menu(aq_data, PM_HOME);
+  goto_pda_menu(aq_data, PM_HOME, false);
 
   cleanAndTerminateThread(threadCtrl);
   return ptr;
@@ -1215,7 +1234,7 @@ void *set_aqualink_PDA_freeze_protectsetpoint( void *ptr )
   if (_PDA_Type != PDA) {
     LOG(PDA_LOG,LOG_INFO, "In PDA AquaPalm mode, freezepoints not supported\n");
     //return false;
-  } else if (! goto_pda_menu(aq_data, PM_FREEZE_PROTECT)) {
+  } else if (! goto_pda_menu(aq_data, PM_FREEZE_PROTECT, true)) {
     LOG(PDA_LOG,LOG_ERR, "Error finding freeze protect setpoints menu\n");
     //return false;
   } else if (! set_PDA_numeric_field_value(aq_data, val, aq_data->frz_protect_set_point, NULL, 1)) {
@@ -1226,7 +1245,7 @@ void *set_aqualink_PDA_freeze_protectsetpoint( void *ptr )
   }
 
   waitfor_pda_queue2empty();
-  goto_pda_menu(aq_data, PM_HOME);
+  goto_pda_menu(aq_data, PM_HOME, false);
 
   cleanAndTerminateThread(threadCtrl);
   return ptr;
@@ -1241,7 +1260,7 @@ void *set_PDA_aqualink_time( void *ptr )
   
   waitForSingleThreadOrTerminate(threadCtrl, AQ_PDA_SET_TIME);
 
-  if (! goto_pda_menu(aq_data, PM_SET_TIME)) {
+  if (! goto_pda_menu(aq_data, PM_SET_TIME, true)) {
     LOG(PDA_LOG,LOG_ERR, "Error finding set time menu\n");
     goto f_end;
   }
@@ -1301,7 +1320,7 @@ Debug:   PDA:       PDA Menu Line 9 = to continue.
 
   waitForPDAnextMenu(aq_data);
   waitfor_pda_queue2empty();
-  goto_pda_menu(aq_data, PM_HOME);
+  goto_pda_menu(aq_data, PM_HOME, false);
 
   f_end:
   
@@ -1325,7 +1344,7 @@ void *get_PDA_aqualink_aux_labels( void *ptr ) {
 
   LOG(PDA_LOG,LOG_INFO, "Finding PDA labels, (BETA ONLY)\n");
 
-  if (! goto_pda_menu(aq_data, PM_AUX_LABEL)) {
+  if (! goto_pda_menu(aq_data, PM_AUX_LABEL, true)) {
     LOG(PDA_LOG,LOG_ERR, "Error finding aux label menu\n");
     goto f_end;
   }
@@ -1340,7 +1359,7 @@ void *get_PDA_aqualink_aux_labels( void *ptr ) {
   // Read first page of devices and make some assumptions.
 
   waitfor_pda_queue2empty();
-  goto_pda_menu(aq_data, PM_HOME);
+  goto_pda_menu(aq_data, PM_HOME, false);
   
   f_end:
   


### PR DESCRIPTION
At time, setting the SWG percent doesn't work. Instead, it turns off the filter pump. Require to bring back to the HOME menu with the first item highlighted. If the home menu does not have the first time highlighted, send the KEY_PDA_BACK again.

Add an option to got back to PDM Home menu with goto_pda_menu. This is used at the beginning of the program sequence only.