### PR TITLE
aq_panel.c: preserve user-set button labels through panel init

### DIFF
--- a/source/aq_panel.c
+++ b/source/aq_panel.c
@@ -1029,7 +1029,7 @@ void initPanelButtons(struct aqualinkdata *aqdata, bool rs, int size, bool combo
   int index = 0;
   aqdata->aqbuttons[index].led = &aqdata->aqualinkleds[7-1];
   aqdata->aqbuttons[index].led->state = LED_S_UNKNOWN;
-  aqdata->aqbuttons[index].label = rs?name2label(BTN_PUMP):cleanalloc(BTN_PDA_PUMP);
+  if (NULL == aqdata->aqbuttons[index].label || 0 == aqdata->aqbuttons[index].label[0]) aqdata->aqbuttons[index].label = rs?name2label(BTN_PUMP):cleanalloc(BTN_PDA_PUMP);
   aqdata->aqbuttons[index].name = BTN_PUMP;
   aqdata->aqbuttons[index].code = KEY_PUMP;
   aqdata->aqbuttons[index].special_mask = 0;
@@ -1039,7 +1039,7 @@ void initPanelButtons(struct aqualinkdata *aqdata, bool rs, int size, bool combo
   if (combo) {
     aqdata->aqbuttons[index].led = &aqdata->aqualinkleds[6-1];
     aqdata->aqbuttons[index].led->state = LED_S_UNKNOWN;
-    aqdata->aqbuttons[index].label = rs?name2label(BTN_SPA):cleanalloc(BTN_PDA_SPA);
+    if (NULL == aqdata->aqbuttons[index].label || 0 == aqdata->aqbuttons[index].label[0]) aqdata->aqbuttons[index].label = rs?name2label(BTN_SPA):cleanalloc(BTN_PDA_SPA);
     aqdata->aqbuttons[index].name = BTN_SPA;
     aqdata->aqbuttons[index].code = KEY_SPA;
     aqdata->aqbuttons[index].special_mask = 0;
@@ -1049,7 +1049,7 @@ void initPanelButtons(struct aqualinkdata *aqdata, bool rs, int size, bool combo
   
   aqdata->aqbuttons[index].led = &aqdata->aqualinkleds[5-1];
   aqdata->aqbuttons[index].led->state = LED_S_UNKNOWN;
-  aqdata->aqbuttons[index].label = rs?name2label(BTN_AUX1):cleanalloc(BTN_PDA_AUX1);
+  if (NULL == aqdata->aqbuttons[index].label || 0 == aqdata->aqbuttons[index].label[0]) aqdata->aqbuttons[index].label = rs?name2label(BTN_AUX1):cleanalloc(BTN_PDA_AUX1);
   aqdata->aqbuttons[index].name = BTN_AUX1;
   aqdata->aqbuttons[index].code = KEY_AUX1;
   aqdata->aqbuttons[index].special_mask = 0;
@@ -1058,7 +1058,7 @@ void initPanelButtons(struct aqualinkdata *aqdata, bool rs, int size, bool combo
   
   aqdata->aqbuttons[index].led = &aqdata->aqualinkleds[4-1];
   aqdata->aqbuttons[index].led->state = LED_S_UNKNOWN;
-  aqdata->aqbuttons[index].label = rs?name2label(BTN_AUX2):cleanalloc(BTN_PDA_AUX2);
+  if (NULL == aqdata->aqbuttons[index].label || 0 == aqdata->aqbuttons[index].label[0]) aqdata->aqbuttons[index].label = rs?name2label(BTN_AUX2):cleanalloc(BTN_PDA_AUX2);
   aqdata->aqbuttons[index].name = BTN_AUX2;
   aqdata->aqbuttons[index].code = KEY_AUX2;
   aqdata->aqbuttons[index].special_mask = 0;
@@ -1067,7 +1067,7 @@ void initPanelButtons(struct aqualinkdata *aqdata, bool rs, int size, bool combo
   
   aqdata->aqbuttons[index].led = &aqdata->aqualinkleds[3-1];
   aqdata->aqbuttons[index].led->state = LED_S_UNKNOWN;
-  aqdata->aqbuttons[index].label = rs?name2label(BTN_AUX3):cleanalloc(BTN_PDA_AUX3);
+  if (NULL == aqdata->aqbuttons[index].label || 0 == aqdata->aqbuttons[index].label[0]) aqdata->aqbuttons[index].label = rs?name2label(BTN_AUX3):cleanalloc(BTN_PDA_AUX3);
   aqdata->aqbuttons[index].name = BTN_AUX3;
   aqdata->aqbuttons[index].code = KEY_AUX3;
   aqdata->aqbuttons[index].special_mask = 0;
@@ -1078,7 +1078,7 @@ void initPanelButtons(struct aqualinkdata *aqdata, bool rs, int size, bool combo
   if (size >= 6) {
     aqdata->aqbuttons[index].led = &aqdata->aqualinkleds[9-1];
     aqdata->aqbuttons[index].led->state = LED_S_UNKNOWN;
-    aqdata->aqbuttons[index].label = rs?name2label(BTN_AUX4):cleanalloc(BTN_PDA_AUX4);
+    if (NULL == aqdata->aqbuttons[index].label || 0 == aqdata->aqbuttons[index].label[0]) aqdata->aqbuttons[index].label = rs?name2label(BTN_AUX4):cleanalloc(BTN_PDA_AUX4);
     aqdata->aqbuttons[index].name = BTN_AUX4;
     aqdata->aqbuttons[index].code = KEY_AUX4;
     aqdata->aqbuttons[index].special_mask = 0;
@@ -1087,7 +1087,7 @@ void initPanelButtons(struct aqualinkdata *aqdata, bool rs, int size, bool combo
 
     aqdata->aqbuttons[index].led = &aqdata->aqualinkleds[8-1];
     aqdata->aqbuttons[index].led->state = LED_S_UNKNOWN;
-    aqdata->aqbuttons[index].label = rs?name2label(BTN_AUX5):cleanalloc(BTN_PDA_AUX5);
+    if (NULL == aqdata->aqbuttons[index].label || 0 == aqdata->aqbuttons[index].label[0]) aqdata->aqbuttons[index].label = rs?name2label(BTN_AUX5):cleanalloc(BTN_PDA_AUX5);
     aqdata->aqbuttons[index].name = BTN_AUX5;
     aqdata->aqbuttons[index].code = KEY_AUX5;
     aqdata->aqbuttons[index].special_mask = 0;
@@ -1098,7 +1098,7 @@ void initPanelButtons(struct aqualinkdata *aqdata, bool rs, int size, bool combo
   if (size >= 8) {
     aqdata->aqbuttons[index].led = &aqdata->aqualinkleds[12-1];
     aqdata->aqbuttons[index].led->state = LED_S_UNKNOWN;
-    aqdata->aqbuttons[index].label = rs?name2label(BTN_AUX6):cleanalloc(BTN_PDA_AUX6);
+    if (NULL == aqdata->aqbuttons[index].label || 0 == aqdata->aqbuttons[index].label[0]) aqdata->aqbuttons[index].label = rs?name2label(BTN_AUX6):cleanalloc(BTN_PDA_AUX6);
     aqdata->aqbuttons[index].name = BTN_AUX6;
     aqdata->aqbuttons[index].code = KEY_AUX6;
     aqdata->aqbuttons[index].special_mask = 0;
@@ -1107,7 +1107,7 @@ void initPanelButtons(struct aqualinkdata *aqdata, bool rs, int size, bool combo
 
     aqdata->aqbuttons[index].led = &aqdata->aqualinkleds[1-1];
     aqdata->aqbuttons[index].led->state = LED_S_UNKNOWN;
-    aqdata->aqbuttons[index].label = rs?name2label(BTN_AUX7):cleanalloc(BTN_PDA_AUX7);
+    if (NULL == aqdata->aqbuttons[index].label || 0 == aqdata->aqbuttons[index].label[0]) aqdata->aqbuttons[index].label = rs?name2label(BTN_AUX7):cleanalloc(BTN_PDA_AUX7);
     aqdata->aqbuttons[index].name = BTN_AUX7;
     aqdata->aqbuttons[index].code = KEY_AUX7;
     aqdata->aqbuttons[index].special_mask = 0;
@@ -1166,7 +1166,7 @@ void initPanelButtons(struct aqualinkdata *aqdata, bool rs, int size, bool combo
   if (size >= 14) { // Actually RS 16 panel, but also 2/14 dual panel.
     aqdata->aqbuttons[index].led = &aqdata->aqualinkleds[21-1];  // doesn't actually exist
     aqdata->aqbuttons[index].led->state = OFF;  // Since there is no LED in data, set to off and allow messages to turn it on
-    aqdata->aqbuttons[index].label = name2label(BTN_AUXB5);
+    if (NULL == aqdata->aqbuttons[index].label || 0 == aqdata->aqbuttons[index].label[0]) aqdata->aqbuttons[index].label = name2label(BTN_AUXB5);
     aqdata->aqbuttons[index].name = BTN_AUXB5;
     aqdata->aqbuttons[index].code = KEY_AUXB5;
     aqdata->aqbuttons[index].special_mask = 0;
@@ -1175,7 +1175,7 @@ void initPanelButtons(struct aqualinkdata *aqdata, bool rs, int size, bool combo
  
     aqdata->aqbuttons[index].led = &aqdata->aqualinkleds[22-1];  // doesn't actually exist
     aqdata->aqbuttons[index].led->state = OFF; // Since there is no LED in data, set to off and allow messages to turn it on
-    aqdata->aqbuttons[index].label = name2label(BTN_AUXB6);
+    if (NULL == aqdata->aqbuttons[index].label || 0 == aqdata->aqbuttons[index].label[0]) aqdata->aqbuttons[index].label = name2label(BTN_AUXB6);
     aqdata->aqbuttons[index].name = BTN_AUXB6;
     aqdata->aqbuttons[index].code = KEY_AUXB6;
     aqdata->aqbuttons[index].special_mask = 0;
@@ -1184,7 +1184,7 @@ void initPanelButtons(struct aqualinkdata *aqdata, bool rs, int size, bool combo
   
     aqdata->aqbuttons[index].led = &aqdata->aqualinkleds[23-1];  // doesn't actually exist
     aqdata->aqbuttons[index].led->state = OFF; // Since there is no LED in data, set to off and allow messages to turn it on
-    aqdata->aqbuttons[index].label = name2label(BTN_AUXB7);
+    if (NULL == aqdata->aqbuttons[index].label || 0 == aqdata->aqbuttons[index].label[0]) aqdata->aqbuttons[index].label = name2label(BTN_AUXB7);
     aqdata->aqbuttons[index].name = BTN_AUXB7;
     aqdata->aqbuttons[index].code = KEY_AUXB7;
     aqdata->aqbuttons[index].rssd_code = RS_SA_AUX14;
@@ -1192,7 +1192,7 @@ void initPanelButtons(struct aqualinkdata *aqdata, bool rs, int size, bool combo
 
     aqdata->aqbuttons[index].led = &aqdata->aqualinkleds[24-1]; // doesn't actually exist
     aqdata->aqbuttons[index].led->state = OFF; // Since there is no LED in data, set to off and allow messages to turn it on
-    aqdata->aqbuttons[index].label = name2label(BTN_AUXB8);
+    if (NULL == aqdata->aqbuttons[index].label || 0 == aqdata->aqbuttons[index].label[0]) aqdata->aqbuttons[index].label = name2label(BTN_AUXB8);
     aqdata->aqbuttons[index].name = BTN_AUXB8;
     aqdata->aqbuttons[index].code = KEY_AUXB8;
     aqdata->aqbuttons[index].special_mask = 0;
@@ -1206,7 +1206,7 @@ void initPanelButtons(struct aqualinkdata *aqdata, bool rs, int size, bool combo
     if (size == 6) {
       aqdata->aqbuttons[index].led = &aqdata->aqualinkleds[12-1];
       aqdata->aqbuttons[index].led->state = LED_S_UNKNOWN;
-      aqdata->aqbuttons[index].label = name2label(BTN_AUX6);
+      if (NULL == aqdata->aqbuttons[index].label || 0 == aqdata->aqbuttons[index].label[0]) aqdata->aqbuttons[index].label = name2label(BTN_AUX6);
       aqdata->aqbuttons[index].name = BTN_AUX6;
       aqdata->aqbuttons[index].code = KEY_AUX6;
       aqdata->aqbuttons[index].special_mask = 0;
@@ -1227,7 +1227,7 @@ void initPanelButtons(struct aqualinkdata *aqdata, bool rs, int size, bool combo
 
   aqdata->aqbuttons[index].led = &aqdata->aqualinkleds[15-1];
   aqdata->aqbuttons[index].led->state = LED_S_UNKNOWN;
-  aqdata->aqbuttons[index].label = rs?name2label(combo?BTN_POOL_HTR:BTN_TEMP1_HTR):cleanalloc(BTN_PDA_POOL_HTR);
+  if (NULL == aqdata->aqbuttons[index].label || 0 == aqdata->aqbuttons[index].label[0]) aqdata->aqbuttons[index].label = rs?name2label(combo?BTN_POOL_HTR:BTN_TEMP1_HTR):cleanalloc(BTN_PDA_POOL_HTR);
   aqdata->aqbuttons[index].name = BTN_POOL_HTR;
   aqdata->aqbuttons[index].code = KEY_POOL_HTR;
   aqdata->aqbuttons[index].special_mask = 0;
@@ -1236,7 +1236,7 @@ void initPanelButtons(struct aqualinkdata *aqdata, bool rs, int size, bool combo
   
   aqdata->aqbuttons[index].led = &aqdata->aqualinkleds[17-1];
   aqdata->aqbuttons[index].led->state = LED_S_UNKNOWN;
-  aqdata->aqbuttons[index].label = rs?name2label(combo?BTN_SPA_HTR:BTN_TEMP2_HTR):cleanalloc(BTN_PDA_SPA_HTR);
+  if (NULL == aqdata->aqbuttons[index].label || 0 == aqdata->aqbuttons[index].label[0]) aqdata->aqbuttons[index].label = rs?name2label(combo?BTN_SPA_HTR:BTN_TEMP2_HTR):cleanalloc(BTN_PDA_SPA_HTR);
   aqdata->aqbuttons[index].name = BTN_SPA_HTR;
   aqdata->aqbuttons[index].code = KEY_SPA_HTR;
   aqdata->aqbuttons[index].special_mask = 0;
@@ -1245,7 +1245,7 @@ void initPanelButtons(struct aqualinkdata *aqdata, bool rs, int size, bool combo
   
   aqdata->aqbuttons[index].led = &aqdata->aqualinkleds[19-1];
   aqdata->aqbuttons[index].led->state = LED_S_UNKNOWN;
-  aqdata->aqbuttons[index].label = rs?name2label(BTN_EXT_AUX):cleanalloc(BTN_PDA_EXT_AUX);
+  if (NULL == aqdata->aqbuttons[index].label || 0 == aqdata->aqbuttons[index].label[0]) aqdata->aqbuttons[index].label = rs?name2label(BTN_EXT_AUX):cleanalloc(BTN_PDA_EXT_AUX);
   aqdata->aqbuttons[index].name = BTN_EXT_AUX;
   aqdata->aqbuttons[index].code = KEY_EXT_AUX;
   aqdata->aqbuttons[index].special_mask = 0;


### PR DESCRIPTION
## Problem

PDA-mode panel init in `initPanelButtons()` unconditionally overwrites every `aqbuttons[].label` with hardcoded `BTN_PDA_*` defaults (`"AUX1"`, `"AUX2"`, etc.) regardless of whether `button_NN_label=` was set in `aqualinkd.conf`.

The config-parse path correctly populates `aqdata->aqbuttons[num].label` (`config.c` line 1105), but `aq_panel.c` line 1032+ runs later and clobbers it.

**Effect**: any installation whose PDA EQUIPMENT ON/OFF menu has been customized away from `AUX1..AUX7` (e.g. `"AIR BLOWER"`, `"CLEANER"`, `"POOL LIGHT"`) cannot toggle those devices via web UI / MQTT / HTTP API. The runtime menu lookup uses the hardcoded `"AUX3"` string, which doesn't exist in the panel's menu, so `find_pda_menu_item()` fails and `set_aqualink_PDA_device_on_off` returns `"device 'AUXN' not found"`.

State **reads** still work (different code path that matches against menu lines directly), which makes the bug particularly confusing — it looks like only writes are broken.

## Repro

PDA-PS6 panel with customized AUX label (e.g. `AUX1` renamed to `CLEANER` in the panel's LABEL AUX menu). `aqualinkd.conf`:
```
panel_type = PD-6 Combo
device_id = 0x61
button_03_label = CLEANER
```

Then:
```bash
mosquitto_pub -h localhost -t aqualinkd/Aux_1/set -m 1
```

Journal shows:
```
PDA Device On/Off, device 'AUX1', state 0
PDA Device programmer couldn't find menu item on any page 'AUX1'
PDA Device On/Off, device 'AUX1' not found
```

(Note: the device name in the log is `'AUX1'` not `'CLEANER'` — confirming that `button->label` has been overwritten between config parse and runtime.)

## Fix

Guard each label assignment in `initPanelButtons()` with a NULL-or-empty check so config-set labels survive:

```c
-  aqdata->aqbuttons[index].label = rs?name2label(BTN_AUX1):cleanalloc(BTN_PDA_AUX1);
+  if (NULL == aqdata->aqbuttons[index].label || 0 == aqdata->aqbuttons[index].label[0])
+    aqdata->aqbuttons[index].label = rs?name2label(BTN_AUX1):cleanalloc(BTN_PDA_AUX1);
```

17 sites total in `initPanelButtons()`. No behavior change when the user has not provided a label.

## Verification (after applying patch + rebuild)

Same panel, same config:
```bash
mosquitto_pub -h localhost -t aqualinkd/Aux_1/set -m 1
```

Journal:
```
PDA Device On/Off, device 'CLEANER', state 0
PDA Device On/Off, found device 'CLEANER', changing state
```

→ Physical equipment toggles. Confirmed on `v3.1.0` master, panel `PDA-PS6 Combo`, AqualinkD running at `device_id=0x61` with handheld off.

## Related

Issue #413 hit the same root cause but for a panel whose menu still had default `AUX1..AUX7` labels — the user's workaround was to set `button_NN_label` to match the panel's menu strings. That works *only* when the panel's menu hasn't been customized. This patch addresses the root cause for the customized-panel case.