### PR TITLE
Allow light use-last-value sentinel through validation

### DIFF
--- a/source/aq_panel.c
+++ b/source/aq_panel.c
@@ -1709,7 +1709,7 @@ void programDeviceLightMode(struct aqualinkdata *aqdata, int value, int deviceIn
     return;
   }
 
-  if (! is_valid_light_mode(light->lightType, value)) {
+  if (value != USE_LAST_VALUE && ! is_valid_light_mode(light->lightType, value)) {
     LOG(PANL_LOG,LOG_ERR, "Light mode '%d' is not valid for light '%s', %s\n", value, lightTypeName(light->lightType), light->button->label);
     return;
   }


### PR DESCRIPTION
## PR Comment

This change fixes light mode requests that use AqualinkD’s internal “use last value” sentinel.

Previously, `USE_LAST_VALUE` (`101`) was passed through the normal light mode validation path. Since `101` is not an actual color mode index, requests such as turning on a configured color light using its last/default mode were rejected with errors like:

```plain text
Light mode '101' is not valid for light 'Jandy Infinite', Pool Light
```


The validation now skips normal mode validation when the requested value is `USE_LAST_VALUE`, allowing the existing downstream logic to handle it as intended.

### Notes

- Real light mode values are still validated normally.
- This only allows the internal sentinel value through; it does not expand the set of valid user-selectable light modes.
- This should address failures when turning on programmable/color lights via paths that request “last mode” rather than a specific color mode.


see [this discussion](https://github.com/aqualinkd/AqualinkD/discussions/523) for more context