### PR TITLE
Improve debug and logging diagnostics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,8 +51,10 @@ jobs:
     - name: Compile AqualinkD
       # Using a standard 'run' block as we are already inside the container
       run: |
-        make clean && \
-        make buildrelease
+        make clean
+        # Pass the workflow revision explicitly because the build container may
+        # not contain git or a .git directory.
+        make GIT_HASH="$(printf '%.7s' "$GITHUB_SHA")" buildrelease
 
     # The remaining steps automatically run inside the container as well
 

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ DBGFLAGS = -g -O0 -Wall -D AQ_DEBUG -D AQ_TM_DEBUG
 #MGFLAGS = -D MG_TLS=2 #(2=MG_TLS_OPENSSL. 3=MG_TLS_BUILTIN) --or--  -DMG_TLS=MG_TLS_BUILTIN
 MGFLAGS = -D MG_TLS=3 -D MG_ENABLE_SSI=0
 
+GIT_HASH := $(shell git rev-parse --short HEAD 2>/dev/null)
+$(info GIT_HASH: $(GIT_HASH) )
+
 # Detect OS and set some specifics
 ifeq ($(OS),Windows_NT)
    # Windows Make.
@@ -100,9 +103,9 @@ endif
 
 
 # Put all flags together.
-CFLAGS = $(GCCFLAGS) $(AQ_FLAGS) $(MGFLAGS)
-DFLAGS = $(DGCCFLAGS) $(AQ_FLAGS) $(MGFLAGS)
-DBG_CFLAGS = $(DBGFLAGS) $(AQ_FLAGS) $(MGFLAGS)
+CFLAGS = $(GCCFLAGS) $(AQ_FLAGS) $(MGFLAGS) -DGIT_HASH="\"$(GIT_HASH)\""
+DFLAGS = $(DGCCFLAGS) $(AQ_FLAGS) $(MGFLAGS) -DGIT_HASH="\"$(GIT_HASH)\""
+DBG_CFLAGS = $(DBGFLAGS) $(AQ_FLAGS) $(MGFLAGS) -DGIT_HASH="\"$(GIT_HASH)\""
 
 # Other sources.
 DBG_SRC = $(SRCS) debug_timer.c
@@ -406,5 +409,3 @@ clean: clean-buildfiles
 
 clean-buildfiles:
 	$(RM) $(wildcard *.o) $(wildcard *~) $(OBJ_FILES) $(DBG_OBJ_FILES) $(SL_OBJ_FILES) $(DD_OBJ_FILES) $(DR_OBJ_FILES) $(OBJ_FILES_ARMHF) $(OBJ_FILES_ARM64) $(OBJ_FILES_AMD64) $(SL_OBJ_FILES_ARMHF) $(SL_OBJ_FILES_ARM64) $(SL_OBJ_FILES_AMD64)
-
-

--- a/release/aqualinkd.conf
+++ b/release/aqualinkd.conf
@@ -26,6 +26,9 @@ serial_port=/dev/ttyUSB0
 log_level=NOTICE
 #log_level=WARNING
 
+# Add millisecond timestamps to foreground logs and log programming thread durations.
+#log_msec_ts=yes
+
 # The directory where the web files are stored
 web_directory=/var/www/aqualinkd/
 

--- a/source/allbutton_aq_programmer.c
+++ b/source/allbutton_aq_programmer.c
@@ -95,7 +95,9 @@ unsigned char pop_allb_cmd(struct aqualinkdata *aqdata)
     if ( _allb_pgm_command != NUL && aqdata->last_packet_type == CMD_STATUS) {
       cmd = _allb_pgm_command;
       _allb_pgm_command = NUL;
-      LOG(ALLB_LOG, LOG_DEBUG_SERIAL, "RS SEND cmd '0x%02hhx' (programming)\n", cmd);
+      if (cmd) {
+        LOG(ALLB_LOG, LOG_DEBUG_SERIAL, "RS SEND cmd %s '0x%02hhx' (programming)\n", cmd_to_string(cmd), cmd);
+      }
     } else if (_allb_pgm_command != NUL) {
       LOG(ALLB_LOG, LOG_DEBUG_SERIAL, "RS Waiting to send cmd '0x%02hhx' (programming)\n", _allb_pgm_command);
     } else {
@@ -1349,7 +1351,7 @@ void send_cmd(unsigned char cmd)
   _allb_pgm_command = cmd;
   //delay(200);
 
-  LOG(ALLB_LOG, LOG_INFO, "Queue send '0x%02hhx' to controller (programming)\n", _allb_pgm_command);
+  LOG(ALLB_LOG, LOG_INFO, "Queue send %s '0x%02hhx' to controller (programming)\n", cmd_to_string(_allb_pgm_command), _allb_pgm_command);
 }
 
 void force_queue_delete()

--- a/source/aq_programmer.c
+++ b/source/aq_programmer.c
@@ -43,10 +43,8 @@
 #include "devices_jandy.h"
 #include "iaqualink.h"
 
-#ifdef AQ_DEBUG
-  #include <time.h>
-  #include "timespec_subtract.h"
-#endif
+#include <time.h>
+#include "timespec_subtract.h"
 
 void _aq_programmer(program_type r_type, char *args, struct aqualinkdata *aqdata, bool allowOveride);
 
@@ -838,9 +836,9 @@ void waitForSingleThreadOrTerminate(struct programmingThreadCtrl *threadCtrl, pr
   threadCtrl->aqdata->active_thread.thread_id = &threadCtrl->thread_id;
   threadCtrl->aqdata->active_thread.ptype = type;
 
-  #ifdef AQ_DEBUG
+  if (_aqconfig_.log_msec_ts) {
     clock_gettime(CLOCK_REALTIME, &threadCtrl->aqdata->start_active_time);
-  #endif
+  }
 
   LOG(PROG_LOG, LOG_INFO, "Programming: %s, %d\n", ptypeName(threadCtrl->aqdata->active_thread.ptype), threadCtrl->aqdata->active_thread.ptype);
 
@@ -856,19 +854,18 @@ void waitForSingleThreadOrTerminate(struct programmingThreadCtrl *threadCtrl, pr
 void cleanAndTerminateThread(struct programmingThreadCtrl *threadCtrl)
 {
   //waitfor_queue2empty();
-  #ifndef AQ_DEBUG
-  LOG(PROG_LOG, LOG_DEBUG, "Thread %d,%p (%s) finished\n",threadCtrl->aqdata->active_thread.ptype, threadCtrl->thread_id,ptypeName(threadCtrl->aqdata->active_thread.ptype));
-  #else
-  struct timespec elapsed;
-  clock_gettime(CLOCK_REALTIME, &threadCtrl->aqdata->last_active_time);
-  timespec_subtract(&elapsed, &threadCtrl->aqdata->last_active_time, &threadCtrl->aqdata->start_active_time);
-  LOG(PROG_LOG, LOG_NOTICE, "Thread %d,%p (%s) finished in %d.%03ld sec\n",
-             threadCtrl->aqdata->active_thread.ptype,
-             threadCtrl->aqdata->active_thread.thread_id,
-             ptypeName(threadCtrl->aqdata->active_thread.ptype),
-             elapsed.tv_sec, elapsed.tv_nsec / 1000000L);
-  #endif
-
+  if (_aqconfig_.log_msec_ts) {
+    struct timespec elapsed;
+    clock_gettime(CLOCK_REALTIME, &threadCtrl->aqdata->last_active_time);
+    timespec_subtract(&elapsed, &threadCtrl->aqdata->last_active_time, &threadCtrl->aqdata->start_active_time);
+    LOG(PROG_LOG, LOG_NOTICE, "Thread %d,%p (%s) finished in %d.%03ld sec\n",
+               threadCtrl->aqdata->active_thread.ptype,
+               threadCtrl->aqdata->active_thread.thread_id,
+               ptypeName(threadCtrl->aqdata->active_thread.ptype),
+               elapsed.tv_sec, elapsed.tv_nsec / 1000000L);
+  } else {
+    LOG(PROG_LOG, LOG_DEBUG, "Thread %d,%p (%s) finished\n",threadCtrl->aqdata->active_thread.ptype, threadCtrl->thread_id,ptypeName(threadCtrl->aqdata->active_thread.ptype));
+  }
   // Quick delay to allow for last message to be sent.
   delay(500);
   threadCtrl->aqdata->active_thread.thread_id = 0;

--- a/source/aq_serial.c
+++ b/source/aq_serial.c
@@ -194,7 +194,7 @@ const char* get_jandy_packet_type(const unsigned char* packet , int length)
       return "PDA Unknown";
     break;
     case CMD_PDA_0x1B:
-      return "PDA Init (*guess*)";
+      return "PDA Init (guess)";
     break;
     case CMD_PDA_HIGHLIGHT:
       return "PDA Hlight";
@@ -1305,33 +1305,25 @@ int get_packet(int fd, unsigned char* packet)
   //clock_gettime(CLOCK_REALTIME, &_last_serial_read_time);
   //}
   //LOG(RSSD_LOG,LOG_DEBUG_SERIAL, "Serial read %d bytes\n",index);
-  if (_aqconfig_.log_protocol_packets || getLogLevel(RSSD_LOG) >= LOG_DEBUG_SERIAL)
+  if (_aqconfig_.log_protocol_packets || getLogLevel(RSSD_LOG) >= LOG_DEBUG_SERIAL) {
     logPacketRead(packet, index);
+  } else {
+    LOG(RSSD_LOG,LOG_DEBUG_SERIAL, "Serial read %d bytes\n",index);
+  }
   // Return the packet length.
   return index;
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+const char* cmd_to_string(const unsigned char cmd)
+{
+  switch (cmd) {
+    case KEY_PDA_UP:      return "UP";
+    case KEY_PDA_DOWN:    return "DOWN";
+    case KEY_PDA_BACK:    return "BACK";
+    case KEY_PDA_SELECT:  return "SELECT";
+    default:              return "UNKNOWN";
+  }
+}
 
 
 

--- a/source/aq_serial.h
+++ b/source/aq_serial.h
@@ -664,4 +664,5 @@ bool onetouch_mode();
 //void send_test_cmd(int fd, unsigned char destination, unsigned char b1, unsigned char b2, unsigned char b3);
 //void send_command(int fd, unsigned char destination, unsigned char b1, unsigned char b2, unsigned char b3);
 //void send_messaged(int fd, unsigned char destination, char *message);
+const char* cmd_to_string(const unsigned char cmd);
 #endif // AQ_SERIAL_H_

--- a/source/aqualink.h
+++ b/source/aqualink.h
@@ -527,11 +527,9 @@ struct aqualinkdata
   int spa_heater_index;
   int solar_heater_index;
   #endif
-  // Timing for DEBUG
-  #ifdef AQ_DEBUG
+  // Timing for millisecond timestamp logging
   struct timespec last_active_time;
   struct timespec start_active_time;
-  #endif
 
   // Overcome color light bug, by reconnecting allbutton panel.
   //bool reconnectAllButton;

--- a/source/aqualinkd.c
+++ b/source/aqualinkd.c
@@ -88,6 +88,7 @@ int _cmdln_loglevel = -1;
 bool _cmdln_debugRS485 = false;
 bool _cmdln_lograwRS485 = false;
 bool _cmdln_nostartupcheck = false;
+bool _cmdln_log_msec_ts = false;
 
 #ifdef AQ_TM_DEBUG
   //struct timespec _rs_packet_readitme;
@@ -450,12 +451,13 @@ void action_delayed_request()
 
 void printHelp()
 {
-  printf("%s %s\n",AQUALINKD_NAME,AQUALINKD_VERSION);
+  printf("%s %s (rev %s)\n", AQUALINKD_NAME, AQUALINKD_VERSION, GIT_HASH);
   printf("\t-h         (this message)\n");
   printf("\t-d         (do not deamonize)\n");
   printf("\t-c <file>  (Configuration file)\n");
   printf("\t-v         (Debug logging)\n");
   printf("\t-vv        (Serial Debug logging)\n");
+  printf("\t-m         (Millisecond timestamps and thread timing)\n");
   printf("\t-rsd       (RS485 debug)\n");
   printf("\t-rsrd      (RS485 raw debug)\n");
 }
@@ -533,6 +535,10 @@ int main(int argc, char *argv[])
     {
       _cmdln_loglevel = LOG_DEBUG;
     }
+    else if (strcmp(argv[i], "-m") == 0)
+    {
+      _cmdln_log_msec_ts = true;
+    }
     else if (strcmp(argv[i], "-rsd") == 0)
     {
       _cmdln_debugRS485 = true;
@@ -597,7 +603,7 @@ int startup(char *self, char *cfgFile)
 
   // Setup a log level just to get this message out, will be re-set once config is read
   setSystemLogLevel(LOG_NOTICE);
-  LOG(AQUA_LOG,LOG_NOTICE, "Starting %s v%s !\n", AQUALINKD_NAME, AQUALINKD_VERSION);
+  LOG(AQUA_LOG,LOG_NOTICE, "Starting %s v%s (rev %s) !\n", AQUALINKD_NAME, AQUALINKD_VERSION, GIT_HASH);
 
   sprintf(_aqualink_data.self, basename(self));
   clearDebugLogMask();
@@ -611,6 +617,11 @@ int startup(char *self, char *cfgFile)
 
   if (_cmdln_lograwRS485)
     _aqconfig_.log_raw_bytes = true;
+
+  if (_cmdln_log_msec_ts)
+    _aqconfig_.log_msec_ts = true;
+
+  setMsecTimestampLog(_aqconfig_.log_msec_ts);
       
 
 #ifdef AQ_MANAGER
@@ -1423,5 +1434,3 @@ void debugtestePump()
   processJandyPacket(fromPumpRPM, 11, &_aqualink_data);
 }
 */
-
-

--- a/source/aqualinkd.c
+++ b/source/aqualinkd.c
@@ -451,7 +451,11 @@ void action_delayed_request()
 
 void printHelp()
 {
-  printf("%s %s (rev %s)\n", AQUALINKD_NAME, AQUALINKD_VERSION, GIT_HASH);
+  if (GIT_HASH[0] != '\0') {
+    printf("%s %s (rev %s)\n", AQUALINKD_NAME, AQUALINKD_VERSION, GIT_HASH);
+  } else {
+    printf("%s %s\n", AQUALINKD_NAME, AQUALINKD_VERSION);
+  }
   printf("\t-h         (this message)\n");
   printf("\t-d         (do not deamonize)\n");
   printf("\t-c <file>  (Configuration file)\n");
@@ -603,7 +607,11 @@ int startup(char *self, char *cfgFile)
 
   // Setup a log level just to get this message out, will be re-set once config is read
   setSystemLogLevel(LOG_NOTICE);
-  LOG(AQUA_LOG,LOG_NOTICE, "Starting %s v%s (rev %s) !\n", AQUALINKD_NAME, AQUALINKD_VERSION, GIT_HASH);
+  if (GIT_HASH[0] != '\0') {
+    LOG(AQUA_LOG,LOG_NOTICE, "Starting %s v%s (rev %s) !\n", AQUALINKD_NAME, AQUALINKD_VERSION, GIT_HASH);
+  } else {
+    LOG(AQUA_LOG,LOG_NOTICE, "Starting %s v%s !\n", AQUALINKD_NAME, AQUALINKD_VERSION);
+  }
 
   sprintf(_aqualink_data.self, basename(self));
   clearDebugLogMask();

--- a/source/config.c
+++ b/source/config.c
@@ -225,6 +225,15 @@ void init_parameters (struct aqconfig * parms)
 
 
   _numCfgParams++;
+  _cfgParams[_numCfgParams].value_ptr = &_aqconfig_.log_msec_ts;
+  _cfgParams[_numCfgParams].value_type = CFG_BOOL;
+  _cfgParams[_numCfgParams].name = CFG_N_log_msec_ts;
+  _cfgParams[_numCfgParams].config_mask |= CFG_GRP_ADVANCED;
+  _cfgParams[_numCfgParams].config_mask |= CFG_FORCE_RESTART;
+  _cfgParams[_numCfgParams].default_value = (void *)&_dcfg_false;
+
+
+  _numCfgParams++;
   _cfgParams[_numCfgParams].value_ptr = &_aqconfig_.mg_log_level;
   _cfgParams[_numCfgParams].value_type = CFG_INT; // Set with _aqconfig_.log_level = text2elevel(cleanalloc(value));
   _cfgParams[_numCfgParams].name = CFG_N_MG_log_level;

--- a/source/config.h
+++ b/source/config.h
@@ -67,6 +67,7 @@ struct aqconfig
   char *serial_port;
   unsigned int log_level;
   unsigned int mg_log_level;
+  bool log_msec_ts;
   char *web_directory;
   char *web_config;
   unsigned char device_id;
@@ -255,6 +256,7 @@ int _numCfgParams;
 #define CFG_N_serial_port                       "serial_port"
 #define CFG_N_log_level                         "log_level"
 #define CFG_N_MG_log_level                      "mg_log_level"
+#define CFG_N_log_msec_ts                       "log_msec_ts"
 #define CFG_V_log_level                         "[\"DEBUG_SERIAL\", \"DEBUG\", \"INFO\", \"NOTICE\", \"WARNING\", \"ERROR\"]"
 #define CFG_N_listen_address                    "listen_address" 
 #define CFG_N_cert_dir                          "https_cert_dir"

--- a/source/json_messages.c
+++ b/source/json_messages.c
@@ -661,7 +661,9 @@ int build_aqualink_aqmanager_JSON(struct aqualinkdata *aqdata, char* buffer, int
   }
 
   length += sprintf(buffer+length, ",\"aqualinkd_version\":\"%s\"",AQUALINKD_VERSION);
-  length += sprintf(buffer+length, ",\"git_revision\":\"%s\"",GIT_HASH);
+  if (GIT_HASH[0] != '\0') {
+    length += sprintf(buffer+length, ",\"git_revision\":\"%s\"",GIT_HASH);
+  }
 
   length += sprintf(buffer+length, ",\"panel_type_full\":\"%s\"",getPanelString());
   length += sprintf(buffer+length, ",\"panel_type\":\"%s\"",getShortPanelString());
@@ -733,7 +735,11 @@ int build_aqualink_status_JSON(struct aqualinkdata *aqdata, char* buffer, int si
   //length += sprintf(buffer+length, ",\"message\":\"%s\"",aqdata->message );
   //length += sprintf(buffer+length, ",\"version\":\"%s\"",aqdata->version );//8157 REV MMM",
   length += sprintf(buffer+length, ",\"version\":\"%s %s\"",aqdata->panel_cpu, aqdata->panel_rev );//8157 REV MMM",
-  length += sprintf(buffer+length, ",\"aqualinkd_version\":\"%s (rev %s)\"", AQUALINKD_VERSION, GIT_HASH); //1.0b,
+  if (GIT_HASH[0] != '\0') {
+    length += sprintf(buffer+length, ",\"aqualinkd_version\":\"%s (rev %s)\"", AQUALINKD_VERSION, GIT_HASH); //1.0b,
+  } else {
+    length += sprintf(buffer+length, ",\"aqualinkd_version\":\"%s\"", AQUALINKD_VERSION); //1.0b,
+  }
   length += sprintf(buffer+length, ",\"date\":\"%s\"",aqdata->date );//"09/01/16 THU",
   length += sprintf(buffer+length, ",\"time\":\"%s\"",aqdata->time );//"1:16 PM",
   //length += sprintf(buffer+length, ",\"air_temp\":\"%d\"",aqdata->air_temp );//"96",

--- a/source/json_messages.c
+++ b/source/json_messages.c
@@ -732,7 +732,7 @@ int build_aqualink_status_JSON(struct aqualinkdata *aqdata, char* buffer, int si
   //length += sprintf(buffer+length, ",\"message\":\"%s\"",aqdata->message );
   //length += sprintf(buffer+length, ",\"version\":\"%s\"",aqdata->version );//8157 REV MMM",
   length += sprintf(buffer+length, ",\"version\":\"%s %s\"",aqdata->panel_cpu, aqdata->panel_rev );//8157 REV MMM",
-  length += sprintf(buffer+length, ",\"aqualinkd_version\":\"%s\"", AQUALINKD_VERSION ); //1.0b,
+  length += sprintf(buffer+length, ",\"aqualinkd_version\":\"%s (rev %s)\"", AQUALINKD_VERSION, GIT_HASH); //1.0b,
   length += sprintf(buffer+length, ",\"date\":\"%s\"",aqdata->date );//"09/01/16 THU",
   length += sprintf(buffer+length, ",\"time\":\"%s\"",aqdata->time );//"1:16 PM",
   //length += sprintf(buffer+length, ",\"air_temp\":\"%d\"",aqdata->air_temp );//"96",

--- a/source/json_messages.c
+++ b/source/json_messages.c
@@ -661,6 +661,7 @@ int build_aqualink_aqmanager_JSON(struct aqualinkdata *aqdata, char* buffer, int
   }
 
   length += sprintf(buffer+length, ",\"aqualinkd_version\":\"%s\"",AQUALINKD_VERSION);
+  length += sprintf(buffer+length, ",\"git_revision\":\"%s\"",GIT_HASH);
 
   length += sprintf(buffer+length, ",\"panel_type_full\":\"%s\"",getPanelString());
   length += sprintf(buffer+length, ",\"panel_type\":\"%s\"",getShortPanelString());

--- a/source/utils.c
+++ b/source/utils.c
@@ -29,10 +29,7 @@
 //#include <time.h>
 #include <ctype.h>
 #include <fcntl.h>
-
-#ifdef AD_DEBUG
 #include <sys/time.h>
-#endif
 
 #ifdef AQ_MANAGER
 #include <systemd/sd-journal.h>
@@ -64,6 +61,7 @@ static bool _cfg_log2file;
 static int _cfg_log_level;
 #endif
 static int _log_level = LOG_WARNING;
+static bool _log_msec_ts = false;
 
 static char *_loq_display_message = NULL;
 logmask_t _logforcemask = 0;
@@ -102,6 +100,11 @@ void setLoggingPrms(int level , bool deamonized, char* log_file, char *error_mes
 void setSystemLogLevel( int level)
 {
   _log_level = level;
+}
+
+void setMsecTimestampLog(bool enabled)
+{
+  _log_msec_ts = enabled;
 }
 int getSystemLogLevel()
 {
@@ -733,19 +736,21 @@ void _LOG(logmask_t from, int msg_level, char *message, int message_buffer_size)
 #endif //AQ_MANAGER
 
   if (_daemonise == FALSE) {
-    if (msg_level == LOG_ERR) {
-      fprintf(stderr, "%s", message);
-    } else {
-#ifndef AD_DEBUG
-      printf("%s", message);
-#else
+    if (_log_msec_ts) {
       struct timespec tspec;
       struct tm localtm;
       clock_gettime(CLOCK_REALTIME, &tspec);
       char timeStr[TIMESTAMP_LENGTH];
       strftime(timeStr, sizeof(timeStr), "%H:%M:%S", localtime_r(&tspec.tv_sec, &localtm));
-      printf("%s.%03ld %s", timeStr, tspec.tv_nsec / 1000000L, message);
-#endif
+      if (msg_level == LOG_ERR) {
+        fprintf(stderr, "%s.%03ld %s", timeStr, tspec.tv_nsec / 1000000L, message);
+      } else {
+        printf("%s.%03ld %s", timeStr, tspec.tv_nsec / 1000000L, message);
+      }
+    } else if (msg_level == LOG_ERR) {
+      fprintf(stderr, "%s", message);
+    } else {
+      printf("%s", message);
     }
   }
 }

--- a/source/utils.h
+++ b/source/utils.h
@@ -91,6 +91,7 @@ void setLoggingPrms(int level , bool deamonized, char* log_file, char *error_mes
 int getLogLevel(logmask_t from);
 int getSystemLogLevel();
 void setSystemLogLevel( int level);
+void setMsecTimestampLog(bool enabled);
 void daemonise ( char *pidFile, void (*main_function)(void) );
 //void debugPrint (char *format, ...);
 

--- a/web/aqmanager.html
+++ b/web/aqmanager.html
@@ -1817,7 +1817,11 @@
       logging2file will tell us if it's currently on or off
     */
     try {
-      document.getElementById("aqualinkdversion").innerHTML = data['aqualinkd_version'];
+      let displayedVersion = data['aqualinkd_version'];
+      if(data['git_revision']) {
+        displayedVersion += " " + data['git_revision'];
+      }
+      document.getElementById("aqualinkdversion").textContent = displayedVersion;
     } catch (e) {}
     if(data['deamonized'] == 'off') {
       //console.log("deamonized=" + data['deamonized'] + " Need to rename Restart to Reload");


### PR DESCRIPTION
Add human-readable command names, apply the serial logging cleanup, and include the Git revision in reported versions.

Make millisecond timestamps and programming-thread duration logging runtime opt-in through configuration or -m.

Reapplies: b29d103, 44453f9, 5c7822c, b7c39c6

Refs: ballle98/AqualinkD#72
Refs: ballle98/AqualinkD#96

Assisted-by: Codex:gpt-5