### PR TITLE
Dev/no polling

### DIFF
--- a/source/allbutton_aq_programmer.c
+++ b/source/allbutton_aq_programmer.c
@@ -23,11 +23,7 @@ bool waitForEitherMessage(struct aqualinkdata *aqdata, char* message1, char* mes
 bool select_sub_menu_item(struct aqualinkdata *aqdata, char* item_string);
 bool select_menu_item(struct aqualinkdata *aqdata, char* item_string);
 
-bool send_cmd(unsigned char cmd);
 void cancel_menu();
-
-void waitfor_queue2empty();
-void longwaitfor_queue2empty();
 
 int _expectNextMessage = 0;
 unsigned char _allb_last_sent_command = NUL;
@@ -43,6 +39,23 @@ bool _last_sent_was_cmd = false;
 
 static pthread_mutex_t _pgm_command_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t _pgm_command_sent_cond = PTHREAD_COND_INITIALIZER;
+typedef enum {
+  PGM_COMMAND_IDLE,
+  PGM_COMMAND_QUEUED,
+  PGM_COMMAND_SENDING
+} pgm_command_state;
+static pgm_command_state _pgm_command_state = PGM_COMMAND_IDLE;
+
+static void set_command_timeout(struct timespec *timeout, unsigned int milliseconds)
+{
+  clock_gettime(CLOCK_REALTIME, timeout);
+  timeout->tv_sec += milliseconds / 1000;
+  timeout->tv_nsec += (milliseconds % 1000) * 1000000L;
+  if (timeout->tv_nsec >= 1000000000L) {
+    timeout->tv_sec++;
+    timeout->tv_nsec -= 1000000000L;
+  }
+}
 
 bool push_allb_cmd(unsigned char cmd);
 
@@ -96,20 +109,19 @@ unsigned char pop_allb_cmd(struct aqualinkdata *aqdata)
   // Are we in programming mode and it's not ONETOUCH programming mode
   if (in_programming_mode(aqdata) && ( in_ot_programming_mode(aqdata) == false  && in_iaqt_programming_mode(aqdata) == false )) {
   //if (aqdata->active_thread.thread_id != 0) {
-    if ( _allb_pgm_command != NUL && aqdata->last_packet_type == CMD_STATUS) {
-      pthread_mutex_lock(&_pgm_command_mutex);
+    pthread_mutex_lock(&_pgm_command_mutex);
+    if (_pgm_command_state == PGM_COMMAND_QUEUED && aqdata->last_packet_type == CMD_STATUS) {
       cmd = _allb_pgm_command;
-      _allb_pgm_command = NUL;
       if (cmd) {
         LOG(ALLB_LOG, LOG_DEBUG_SERIAL, "RS SEND cmd %s '0x%02hhx' (programming)\n", cmd_to_string(cmd), cmd);
       }
-      pthread_cond_signal(&_pgm_command_sent_cond);
-      pthread_mutex_unlock(&_pgm_command_mutex);
-    } else if (_allb_pgm_command != NUL) {
+      _pgm_command_state = PGM_COMMAND_SENDING;
+    } else if (_pgm_command_state != PGM_COMMAND_IDLE) {
       LOG(ALLB_LOG, LOG_DEBUG_SERIAL, "RS Waiting to send cmd '0x%02hhx' (programming)\n", _allb_pgm_command);
     } else {
       LOG(ALLB_LOG, LOG_DEBUG_SERIAL, "RS SEND cmd '0x%02hhx' empty queue (programming)\n", cmd);
     }
+    pthread_mutex_unlock(&_pgm_command_mutex);
   } else if (_allb_stack_place > 0 && aqdata->last_packet_type == CMD_STATUS ) {
     cmd = _allb_commands[0];
     _allb_stack_place--;
@@ -128,6 +140,20 @@ unsigned char pop_allb_cmd(struct aqualinkdata *aqdata)
   }
   
   return cmd;
+}
+
+void allbutton_command_sent(unsigned char cmd)
+{
+  if (cmd == NUL)
+    return;
+
+  pthread_mutex_lock(&_pgm_command_mutex);
+  if (_pgm_command_state == PGM_COMMAND_SENDING && _allb_pgm_command == cmd) {
+    _allb_pgm_command = NUL;
+    _pgm_command_state = PGM_COMMAND_IDLE;
+    pthread_cond_broadcast(&_pgm_command_sent_cond);
+  }
+  pthread_mutex_unlock(&_pgm_command_mutex);
 }
 
 
@@ -1321,32 +1347,39 @@ void send_cmd(unsigned char cmd, struct aqualinkdata *aqdata)
 
 void _waitfor_queue2empty(bool longwait)
 {
-  int i=0;
+  int ret = 0;
+  struct timespec max_wait;
 
-  if (_allb_pgm_command != NUL) {
+  set_command_timeout(&max_wait, PROGRAMMING_POLL_DELAY_TIME * PROGRAMMING_POLL_COUNTER * (longwait ? 2 : 1));
+
+  pthread_mutex_lock(&_pgm_command_mutex);
+  if (_pgm_command_state != PGM_COMMAND_IDLE) {
     LOG(ALLB_LOG, LOG_DEBUG, "Waiting for queue to empty\n");
   } else {
     LOG(ALLB_LOG, LOG_DEBUG, "Queue empty!\n");
+    pthread_mutex_unlock(&_pgm_command_mutex);
     return;
   }
 
-  while ( (_allb_pgm_command != NUL) && ( i++ < (PROGRAMMING_POLL_COUNTER*(longwait?2:1) ) ) ) {
-    delay(PROGRAMMING_POLL_DELAY_TIME);
+  while (_pgm_command_state != PGM_COMMAND_IDLE) {
+    ret = pthread_cond_timedwait(&_pgm_command_sent_cond, &_pgm_command_mutex, &max_wait);
+    if (ret != 0)
+      break;
   }
 
-  if (_allb_pgm_command != NUL) {
-    LOG(ALLB_LOG, LOG_WARNING, "Send command Queue did not empty, timeout\n");
+  if (_pgm_command_state != PGM_COMMAND_IDLE) {
+    LOG(ALLB_LOG, LOG_WARNING, "Send command queue did not empty: %s\n", strerror(ret));
   } else {
     LOG(ALLB_LOG, LOG_DEBUG, "Queue now empty!\n");
   }
-
+  pthread_mutex_unlock(&_pgm_command_mutex);
 }
 
-void waitfor_queue2empty()
+void waitfor_queue2empty(void)
 {
   _waitfor_queue2empty(false);
 }
-void longwaitfor_queue2empty()
+void longwaitfor_queue2empty(void)
 {
   _waitfor_queue2empty(true);
 }
@@ -1357,16 +1390,41 @@ bool send_cmd(unsigned char cmd)
   int pret = 0;
   struct timespec max_wait;
 
-  clock_gettime(CLOCK_REALTIME, &max_wait);
-  max_wait.tv_sec += 5;
+  if (cmd == NUL) {
+    LOG(PROG_LOG, LOG_ERR, "Refusing to queue empty programming command\n");
+    return false;
+  }
+
+  set_command_timeout(&max_wait, 5000);
 
   pthread_mutex_lock(&_pgm_command_mutex);
+  while (_pgm_command_state != PGM_COMMAND_IDLE) {
+    pret = pthread_cond_timedwait(&_pgm_command_sent_cond,
+                                 &_pgm_command_mutex, &max_wait);
+    if (pret != 0) {
+      LOG(PROG_LOG, LOG_ERR, "send_cmd 0x%02hhx could not acquire command slot: %s\n",
+                         cmd, strerror(pret));
+      pthread_mutex_unlock(&_pgm_command_mutex);
+      return false;
+    }
+  }
+
   _allb_pgm_command = cmd;
+  _pgm_command_state = PGM_COMMAND_QUEUED;
   LOG(ALLB_LOG, LOG_INFO, "Queue send %s '0x%02hhx' to controller (programming)\n", cmd_to_string(_allb_pgm_command), _allb_pgm_command);
-  while (_allb_pgm_command != NUL) {
+  while (_pgm_command_state != PGM_COMMAND_IDLE) {
     if ((pret = pthread_cond_timedwait(&_pgm_command_sent_cond,
                                       &_pgm_command_mutex, &max_wait))) {
-      LOG(PROG_LOG, LOG_ERR, "send_cmd 0x%02hhx err %s\n", cmd, strerror(pret));
+      if (_pgm_command_state == PGM_COMMAND_QUEUED) {
+        _allb_pgm_command = NUL;
+        _pgm_command_state = PGM_COMMAND_IDLE;
+        pthread_cond_broadcast(&_pgm_command_sent_cond);
+        LOG(PROG_LOG, LOG_ERR, "send_cmd 0x%02hhx canceled before transmission: %s\n",
+                           cmd, strerror(pret));
+      } else {
+        LOG(PROG_LOG, LOG_ERR, "send_cmd 0x%02hhx transmission not confirmed: %s\n",
+                           cmd, strerror(pret));
+      }
       ret = false;
       break;
     }
@@ -1380,10 +1438,11 @@ bool send_cmd(unsigned char cmd)
 
 void force_queue_delete()
 {
-  //if (_allb_pgm_command != NUL)
-  //  LOG(ALLB_LOG, LOG_INFO, "Really bad coding, don't use this in release\n");
-
+  pthread_mutex_lock(&_pgm_command_mutex);
   _allb_pgm_command = NUL;
+  _pgm_command_state = PGM_COMMAND_IDLE;
+  pthread_cond_broadcast(&_pgm_command_sent_cond);
+  pthread_mutex_unlock(&_pgm_command_mutex);
 }
 
 

--- a/source/allbutton_aq_programmer.c
+++ b/source/allbutton_aq_programmer.c
@@ -2,6 +2,7 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <pthread.h>
+#include <time.h>
 #include <unistd.h>
 #include <string.h>
 
@@ -22,7 +23,7 @@ bool waitForEitherMessage(struct aqualinkdata *aqdata, char* message1, char* mes
 bool select_sub_menu_item(struct aqualinkdata *aqdata, char* item_string);
 bool select_menu_item(struct aqualinkdata *aqdata, char* item_string);
 
-void send_cmd(unsigned char cmd);
+bool send_cmd(unsigned char cmd);
 void cancel_menu();
 
 void waitfor_queue2empty();
@@ -39,6 +40,9 @@ unsigned char _allb_pgm_command = NUL;
 //unsigned char _ot_allb_pgm_command = NUL;
 
 bool _last_sent_was_cmd = false;
+
+static pthread_mutex_t _pgm_command_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t _pgm_command_sent_cond = PTHREAD_COND_INITIALIZER;
 
 bool push_allb_cmd(unsigned char cmd);
 
@@ -93,11 +97,14 @@ unsigned char pop_allb_cmd(struct aqualinkdata *aqdata)
   if (in_programming_mode(aqdata) && ( in_ot_programming_mode(aqdata) == false  && in_iaqt_programming_mode(aqdata) == false )) {
   //if (aqdata->active_thread.thread_id != 0) {
     if ( _allb_pgm_command != NUL && aqdata->last_packet_type == CMD_STATUS) {
+      pthread_mutex_lock(&_pgm_command_mutex);
       cmd = _allb_pgm_command;
       _allb_pgm_command = NUL;
       if (cmd) {
         LOG(ALLB_LOG, LOG_DEBUG_SERIAL, "RS SEND cmd %s '0x%02hhx' (programming)\n", cmd_to_string(cmd), cmd);
       }
+      pthread_cond_signal(&_pgm_command_sent_cond);
+      pthread_mutex_unlock(&_pgm_command_mutex);
     } else if (_allb_pgm_command != NUL) {
       LOG(ALLB_LOG, LOG_DEBUG_SERIAL, "RS Waiting to send cmd '0x%02hhx' (programming)\n", _allb_pgm_command);
     } else {
@@ -1344,14 +1351,31 @@ void longwaitfor_queue2empty()
   _waitfor_queue2empty(true);
 }
 
-void send_cmd(unsigned char cmd)
+bool send_cmd(unsigned char cmd)
 {
-  waitfor_queue2empty();
-  
-  _allb_pgm_command = cmd;
-  //delay(200);
+  bool ret = true;
+  int pret = 0;
+  struct timespec max_wait;
 
+  clock_gettime(CLOCK_REALTIME, &max_wait);
+  max_wait.tv_sec += 5;
+
+  pthread_mutex_lock(&_pgm_command_mutex);
+  _allb_pgm_command = cmd;
   LOG(ALLB_LOG, LOG_INFO, "Queue send %s '0x%02hhx' to controller (programming)\n", cmd_to_string(_allb_pgm_command), _allb_pgm_command);
+  while (_allb_pgm_command != NUL) {
+    if ((pret = pthread_cond_timedwait(&_pgm_command_sent_cond,
+                                      &_pgm_command_mutex, &max_wait))) {
+      LOG(PROG_LOG, LOG_ERR, "send_cmd 0x%02hhx err %s\n", cmd, strerror(pret));
+      ret = false;
+      break;
+    }
+  }
+  if (ret)
+    LOG(PROG_LOG, LOG_INFO, "sent '0x%02hhx' to controller\n", cmd);
+  pthread_mutex_unlock(&_pgm_command_mutex);
+
+  return ret;
 }
 
 void force_queue_delete()

--- a/source/allbutton_aq_programmer.h
+++ b/source/allbutton_aq_programmer.h
@@ -1,6 +1,7 @@
 #ifndef ALLBUTTON_PROGRAMMER_H_
 #define ALLBUTTON_PROGRAMMER_H_
 
+#include <stdbool.h>
 
 void *set_allbutton_pool_heater_temps( void *ptr );
 void *set_allbutton_spa_heater_temps( void *ptr );
@@ -19,9 +20,13 @@ void *set_allbutton_SWG( void *ptr );
 void *set_allbutton_boost( void *ptr );
 
 unsigned char pop_allb_cmd(struct aqualinkdata *aq_data);
+void allbutton_command_sent(unsigned char cmd);
 
 
 
 void aq_send_allb_cmd(unsigned char cmd);
+bool send_cmd(unsigned char cmd);
+void waitfor_queue2empty(void);
+void longwaitfor_queue2empty(void);
 
 #endif //ALLBUTTON_PROGRAMMER_H_

--- a/source/aq_programmer.c
+++ b/source/aq_programmer.c
@@ -832,7 +832,7 @@ void waitForSingleThreadOrTerminate(struct programmingThreadCtrl *threadCtrl, pr
   struct timespec max_wait;
 
   clock_gettime(CLOCK_REALTIME, &max_wait);
-  max_wait.tv_sec += 30;
+  max_wait.tv_sec += 120;
 
   // Make sure to update UI
   SET_DIRTY(threadCtrl->aqdata->is_dirty);
@@ -848,18 +848,18 @@ void waitForSingleThreadOrTerminate(struct programmingThreadCtrl *threadCtrl, pr
     pthread_exit(0);
   }
 */
-  pthread_mutex_lock(&threadCtrl->aqdata->active_thread.thread_mutex);
+  pthread_mutex_lock(&threadCtrl->aqdata->active_thread.lifecycle_mutex);
   while (threadCtrl->aqdata->active_thread.thread_id != 0) {
     LOG(PROG_LOG, LOG_DEBUG, "Thread %p (%s) sleeping, waiting for thread %p (%s) to finish\n",
                 &threadCtrl->thread_id, ptypeName(type),
                 threadCtrl->aqdata->active_thread.thread_id, ptypeName(threadCtrl->aqdata->active_thread.ptype));
-    if ((ret = pthread_cond_timedwait(&threadCtrl->aqdata->active_thread.thread_cond,
-                                      &threadCtrl->aqdata->active_thread.thread_mutex, &max_wait))) {
+    if ((ret = pthread_cond_timedwait(&threadCtrl->aqdata->active_thread.lifecycle_cond,
+                                      &threadCtrl->aqdata->active_thread.lifecycle_mutex, &max_wait))) {
       LOG(PROG_LOG, LOG_ERR, "Thread %p (%s) err %s waiting for thread %p (%s) to finish\n",
                   &threadCtrl->thread_id, ptypeName(type), strerror(ret),
                   threadCtrl->aqdata->active_thread.thread_id,
                   ptypeName(threadCtrl->aqdata->active_thread.ptype));
-      pthread_mutex_unlock(&threadCtrl->aqdata->active_thread.thread_mutex);
+      pthread_mutex_unlock(&threadCtrl->aqdata->active_thread.lifecycle_mutex);
       free(threadCtrl);
       pthread_exit(0);
     }
@@ -883,12 +883,12 @@ void waitForSingleThreadOrTerminate(struct programmingThreadCtrl *threadCtrl, pr
 
   // Make sure to update UI
   SET_DIRTY(threadCtrl->aqdata->is_dirty);
-  pthread_mutex_unlock(&threadCtrl->aqdata->active_thread.thread_mutex);
+  pthread_mutex_unlock(&threadCtrl->aqdata->active_thread.lifecycle_mutex);
 }
 
 void cleanAndTerminateThread(struct programmingThreadCtrl *threadCtrl)
 {
-  pthread_mutex_lock(&threadCtrl->aqdata->active_thread.thread_mutex);
+  pthread_mutex_lock(&threadCtrl->aqdata->active_thread.lifecycle_mutex);
   if (_aqconfig_.log_msec_ts) {
     struct timespec elapsed;
     clock_gettime(CLOCK_REALTIME, &threadCtrl->aqdata->last_active_time);
@@ -903,8 +903,8 @@ void cleanAndTerminateThread(struct programmingThreadCtrl *threadCtrl)
   }
   threadCtrl->aqdata->active_thread.thread_id = 0;
   threadCtrl->aqdata->active_thread.ptype = AQP_NULL;
-  pthread_cond_signal(&threadCtrl->aqdata->active_thread.thread_cond);
-  pthread_mutex_unlock(&threadCtrl->aqdata->active_thread.thread_mutex);
+  pthread_cond_broadcast(&threadCtrl->aqdata->active_thread.lifecycle_cond);
+  pthread_mutex_unlock(&threadCtrl->aqdata->active_thread.lifecycle_mutex);
   threadCtrl->thread_id = 0;
   // Force update, change display message
   //threadCtrl->aqdata->is_dirty = true;

--- a/source/aq_programmer.c
+++ b/source/aq_programmer.c
@@ -18,6 +18,7 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <pthread.h>
+#include <time.h>
 #include <unistd.h>
 #include <string.h>
 
@@ -827,10 +828,11 @@ void _aq_programmer_(program_type r_type, char *args, aqkey *button, int value, 
 
 void waitForSingleThreadOrTerminate(struct programmingThreadCtrl *threadCtrl, program_type type)
 {
-  //static int tries = 120;
-  int tries = 120;
-  static int waitTime = 1;
-  int i=0;
+  int ret = 0;
+  struct timespec max_wait;
+
+  clock_gettime(CLOCK_REALTIME, &max_wait);
+  max_wait.tv_sec += 30;
 
   // Make sure to update UI
   SET_DIRTY(threadCtrl->aqdata->is_dirty);
@@ -846,21 +848,21 @@ void waitForSingleThreadOrTerminate(struct programmingThreadCtrl *threadCtrl, pr
     pthread_exit(0);
   }
 */
-  while ( (threadCtrl->aqdata->active_thread.thread_id != 0) && ( i++ <= tries) ) {
-    //LOG(PROG_LOG, LOG_DEBUG, "Thread %d sleeping, waiting for thread %d to finish\n", threadCtrl->thread_id, threadCtrl->aqdata->active_thread.thread_id);
+  pthread_mutex_lock(&threadCtrl->aqdata->active_thread.thread_mutex);
+  while (threadCtrl->aqdata->active_thread.thread_id != 0) {
     LOG(PROG_LOG, LOG_DEBUG, "Thread %p (%s) sleeping, waiting for thread %p (%s) to finish\n",
                 &threadCtrl->thread_id, ptypeName(type),
                 threadCtrl->aqdata->active_thread.thread_id, ptypeName(threadCtrl->aqdata->active_thread.ptype));
-    sleep(waitTime);
-  }
-  
-  if (i >= tries) {
-    //LOG(PROG_LOG, LOG_ERR, "Thread %d timeout waiting, ending\n",threadCtrl->thread_id);
-    LOG(PROG_LOG, LOG_ERR, "Thread (%s) %p timeout waiting for thread (%s) %p to finish\n",
-                ptypeName(type), &threadCtrl->thread_id, ptypeName(threadCtrl->aqdata->active_thread.ptype),
-                threadCtrl->aqdata->active_thread.thread_id);
-    free(threadCtrl);
-    pthread_exit(0);
+    if ((ret = pthread_cond_timedwait(&threadCtrl->aqdata->active_thread.thread_cond,
+                                      &threadCtrl->aqdata->active_thread.thread_mutex, &max_wait))) {
+      LOG(PROG_LOG, LOG_ERR, "Thread %p (%s) err %s waiting for thread %p (%s) to finish\n",
+                  &threadCtrl->thread_id, ptypeName(type), strerror(ret),
+                  threadCtrl->aqdata->active_thread.thread_id,
+                  ptypeName(threadCtrl->aqdata->active_thread.ptype));
+      pthread_mutex_unlock(&threadCtrl->aqdata->active_thread.thread_mutex);
+      free(threadCtrl);
+      pthread_exit(0);
+    }
   }
  
   // Clear out any messages to the UI.
@@ -881,11 +883,12 @@ void waitForSingleThreadOrTerminate(struct programmingThreadCtrl *threadCtrl, pr
 
   // Make sure to update UI
   SET_DIRTY(threadCtrl->aqdata->is_dirty);
+  pthread_mutex_unlock(&threadCtrl->aqdata->active_thread.thread_mutex);
 }
 
 void cleanAndTerminateThread(struct programmingThreadCtrl *threadCtrl)
 {
-  //waitfor_queue2empty();
+  pthread_mutex_lock(&threadCtrl->aqdata->active_thread.thread_mutex);
   if (_aqconfig_.log_msec_ts) {
     struct timespec elapsed;
     clock_gettime(CLOCK_REALTIME, &threadCtrl->aqdata->last_active_time);
@@ -898,10 +901,10 @@ void cleanAndTerminateThread(struct programmingThreadCtrl *threadCtrl)
   } else {
     LOG(PROG_LOG, LOG_DEBUG, "Thread %d,%p (%s) finished\n",threadCtrl->aqdata->active_thread.ptype, threadCtrl->thread_id,ptypeName(threadCtrl->aqdata->active_thread.ptype));
   }
-  // Quick delay to allow for last message to be sent.
-  delay(500);
   threadCtrl->aqdata->active_thread.thread_id = 0;
   threadCtrl->aqdata->active_thread.ptype = AQP_NULL;
+  pthread_cond_signal(&threadCtrl->aqdata->active_thread.thread_cond);
+  pthread_mutex_unlock(&threadCtrl->aqdata->active_thread.thread_mutex);
   threadCtrl->thread_id = 0;
   // Force update, change display message
   //threadCtrl->aqdata->is_dirty = true;

--- a/source/aqualink.h
+++ b/source/aqualink.h
@@ -128,6 +128,8 @@ struct programmingthread {
   pthread_t *thread_id;
   pthread_mutex_t thread_mutex;
   pthread_cond_t thread_cond;
+  pthread_mutex_t lifecycle_mutex;
+  pthread_cond_t lifecycle_cond;
   program_type ptype;
   //void *thread_args;
 };

--- a/source/aqualinkd.c
+++ b/source/aqualinkd.c
@@ -726,8 +726,12 @@ void caculate_ack_packet(int rs_fd, unsigned char *packet_buffer, emulation_type
 
   switch (source) {
     case ALLBUTTON:
-      send_extended_ack(rs_fd, (packet_buffer[PKT_CMD]==CMD_MSG_LONG?ACK_SCREEN_BUSY_SCROLL:ACK_NORMAL), pop_allb_cmd(&_aqualink_data));
+    {
+      unsigned char command = pop_allb_cmd(&_aqualink_data);
+      send_extended_ack(rs_fd, (packet_buffer[PKT_CMD]==CMD_MSG_LONG?ACK_SCREEN_BUSY_SCROLL:ACK_NORMAL), command);
+      allbutton_command_sent(command);
       //DEBUG_TIMER_STOP(_rs_packet_timer,AQUA_LOG,"AllButton Emulation type Processed packet in");
+    }
     break;
     case RSSADAPTER:
       send_jandy_command(rs_fd, get_rssa_cmd(packet_buffer[PKT_CMD]), 4);
@@ -768,7 +772,9 @@ void caculate_ack_packet(int rs_fd, unsigned char *packet_buffer, emulation_type
         LOG(PDA_LOG,LOG_DEBUG, "PDA Aqualink daemon in sleep mode\n");
         return;
       } else {
-        send_extended_ack(rs_fd, ACK_PDA, pop_pda_cmd(&_aqualink_data));
+        unsigned char command = pop_pda_cmd(&_aqualink_data);
+        send_extended_ack(rs_fd, ACK_PDA, command);
+        allbutton_command_sent(command);
       }
       //DEBUG_TIMER_STOP(_rs_packet_timer,AQUA_LOG,"PDA Emulation type Processed packet in");
     break;
@@ -875,6 +881,8 @@ void main_loop()
 
   pthread_mutex_init(&_aqualink_data.active_thread.thread_mutex, NULL);
   pthread_cond_init(&_aqualink_data.active_thread.thread_cond, NULL);
+  pthread_mutex_init(&_aqualink_data.active_thread.lifecycle_mutex, NULL);
+  pthread_cond_init(&_aqualink_data.active_thread.lifecycle_cond, NULL);
 
   //for (i=0; i < MAX_PUMPS; i++) {
   for (i=0; i < _aqualink_data.num_pumps; i++) {

--- a/source/pda_aq_programmer.c
+++ b/source/pda_aq_programmer.c
@@ -34,6 +34,7 @@
 #include "pda_aq_programmer.h"
 #include "config.h"
 #include "aq_panel.h"
+#include "allbutton_aq_programmer.h"
 #include "rs_msg_utils.h"
 #include "color_lights.h"
 
@@ -62,9 +63,6 @@ static pda_type _PDA_Type;
 
 #ifndef USE_ALLBUTTON_QUEUE
 /* Forcing all these to allbutton for the moment */
-void waitfor_queue2empty();
-void send_cmd(unsigned char cmd);
-unsigned char pop_allb_cmd(struct aqualinkdata *aqdata);
 int get_allb_queue_length();
 
 void waitfor_pda_queue2empty() {

--- a/source/pda_aq_programmer.h
+++ b/source/pda_aq_programmer.h
@@ -47,7 +47,7 @@ void *set_aqualink_PDA_light_mode( void *ptr );
 
 /*
 // These are from aq_programmer.c , exposed here for PDA AQ PROGRAMMER
-void send_cmd(unsigned char cmd);
+bool send_cmd(unsigned char cmd);
 bool push_aq_cmd(unsigned char cmd);
 bool waitForMessage(struct aqualinkdata *aq_data, char* message, int numMessageReceived);
 void waitfor_queue2empty();

--- a/source/pda_aq_programmer.h
+++ b/source/pda_aq_programmer.h
@@ -45,16 +45,6 @@ void *set_PDA_aqualink_time( void *ptr );
 
 void *set_aqualink_PDA_light_mode( void *ptr );
 
-/*
-// These are from aq_programmer.c , exposed here for PDA AQ PROGRAMMER
-bool send_cmd(unsigned char cmd);
-bool push_aq_cmd(unsigned char cmd);
-bool waitForMessage(struct aqualinkdata *aq_data, char* message, int numMessageReceived);
-void waitfor_queue2empty();
-void longwaitfor_queue2empty();
-*/
-
-
 //void pda_programming_thread_check(struct aqualinkdata *aq_data);
 
 #endif // AQ_PDA_PROGRAMMER_H_


### PR DESCRIPTION
## Summary

This PR replaces internal sleep-and-check polling loops with pthread condition variables.

Programming threads now wake immediately when:

- A queued command reaches the RS485 send path.
- The active programming operation finishes.
- A command slot is canceled or becomes available.

It also introduces an explicit command state machine:

```text
IDLE → QUEUED → SENDING → IDLE
```

This ensures a command is not considered complete merely because it was removed from the queue—it must reach the serial-send path first.

## Why This Is Necessary

The previous implementation repeatedly woke threads to inspect shared state. This caused unnecessary CPU wakeups, delayed programming-thread handoffs, and created timing windows where a command could appear complete before it was sent.

The new synchronization:

- Reduces unnecessary CPU activity.
- Provides immediate thread wakeups.
- Prevents command-slot races.
- Reliably serializes programming operations.
- Removes dependency on arbitrary sleep delays.

This only changes AqualinkD’s internal thread synchronization. It does not remove or alter the controller’s normal RS485 polling protocol.