### PR TITLE
Fix panel clock being set ~1 minute slow

### DIFF
--- a/release/aqualinkd.conf
+++ b/release/aqualinkd.conf
@@ -157,6 +157,15 @@ ftdi_low_latency=YES
 # Keep the panel time synced with systemtime.  Make sure to set systemtime / NTP correctly. 
 sync_panel_time = yes
 
+# Sync the panel time once at every AqualinkD startup, even when the panel clock is
+# already within the normal tolerance (2 minutes) that would otherwise leave it alone.
+# Requires sync_panel_time = yes.
+# The panel has no seconds field, so setting it means holding the panel's SET TIME menu
+# for a minute or two while AqualinkD waits to commit the entry exactly on a minute
+# boundary.  Off by default because that is a real (if brief) interruption to do on every
+# restart, but useful if your panel loses time when power cycled.
+#force_panel_time_sync_at_startup = no
+
 # Display any warnings in web UI
 display_warnings_in_web = yes
 

--- a/release/aqualinkd.conf
+++ b/release/aqualinkd.conf
@@ -158,12 +158,17 @@ ftdi_low_latency=YES
 sync_panel_time = yes
 
 # Sync the panel time once at every AqualinkD startup, even when the panel clock is
-# already within the normal tolerance (2 minutes) that would otherwise leave it alone.
+# already within the tolerance that would otherwise leave it alone.  That tolerance is
+# 15 seconds on an RS panel (where AqualinkD can time the panel's own minute rollover),
+# 40 seconds when it cannot, and 120 seconds on iAQ Touch and PDA panels whose set-time
+# routine cannot land any closer than that.
 # Requires sync_panel_time = yes.
-# The panel has no seconds field, so setting it means holding the panel's SET TIME menu
-# for a minute or two while AqualinkD waits to commit the entry exactly on a minute
-# boundary.  Off by default because that is a real (if brief) interruption to do on every
-# restart, but useful if your panel loses time when power cycled.
+# Setting the clock takes over the panel's menus for roughly the length of the keypress
+# walk, usually 5 to 30 seconds - AqualinkD waits for the minute boundary BEFORE opening
+# SET TIME, not while holding it.  The sync is also deferred 60 seconds after startup so
+# it does not stall everything else AqualinkD is reading.
+# Off by default because it is still a brief interruption to do on every restart, but
+# useful if your panel loses time when power cycled.
 #force_panel_time_sync_at_startup = no
 
 # Display any warnings in web UI

--- a/source/allbutton_aq_programmer.c
+++ b/source/allbutton_aq_programmer.c
@@ -52,6 +52,7 @@ void longwaitfor_queue2empty();
 #define AQ_SETTIME_STAGE_BASE     3  /* fixed cost of staging, on top of the presses */
 #define AQ_SETTIME_NAV_ALLOWANCE 12  /* menu walk to SET TIME; measured 3.5s, retries x3 */
 #define AQ_SETTIME_PRESSES_MAX  140  /* used when the panel display cannot be parsed */
+#define AQ_SETTIME_DEADLINE_SLACK 15 /* added to the derived staging time for the deadline */
 
 /*
 * Read the date and time the panel is currently displaying, e.g. "09/04/26 FRI" and
@@ -136,6 +137,60 @@ static int settime_panel_offset(struct aqualinkdata *aqdata, time_t now)
     return INT_MAX;
 
   return abs((int)(now - panel));
+}
+
+/*
+* Choose the boundary to commit on, together with the staging cost FOR THAT BOUNDARY.
+*
+* The two are circular: the press count depends on the target minute, the target minute
+* depends on the lead, and the lead depends on the press count.  So iterate to a fixed
+* point, then recompute once more against whatever we settled on.  That last step is the
+* important one - the numeric fields do not wrap, so a target one minute later can cost
+* wildly more (a panel showing 12:58 needs 1 press for a 12:59 target and 58 for 13:00),
+* and figures describing a target we are not using are worse than useless.
+*
+* Guarantees on return: presses/stage/lead all describe *target, and target is far enough
+* out to fit them.
+*/
+static void settime_plan(struct aqualinkdata *aqdata, time_t now, time_t *target_out,
+                         int *presses_out, int *stage_out, int *lead_out)
+{
+  struct tm tm_t;
+  time_t target = now;
+  int presses = AQ_SETTIME_PRESSES_MAX;   /* conservative seed for the first pass */
+  int stage, lead, next, i;
+
+  for (i = 0; i < 4; i++) {
+    stage = settime_stage_secs(presses);
+    lead  = AQ_SETTIME_NAV_ALLOWANCE + stage;
+    target = ((now + lead) / 60) * 60;               // boundary at or before now+lead
+    if (target < now + lead)
+      target += 60;                                  // first boundary at or after
+    localtime_r(&target, &tm_t);
+    next = settime_expected_presses(aqdata, &tm_t);
+    if (next == presses)
+      break;                                         // settled
+    presses = next;
+  }
+
+  /* Make the figures describe the target we are actually returning, and step out a
+     minute at a time if that makes it unreachable.  Terminates: lead can never exceed
+     settime_stage_secs(AQ_SETTIME_PRESSES_MAX) + AQ_SETTIME_NAV_ALLOWANCE, so a couple
+     of minutes of headroom always wins. */
+  for (i = 0; i < 4; i++) {
+    localtime_r(&target, &tm_t);
+    presses = settime_expected_presses(aqdata, &tm_t);
+    stage   = settime_stage_secs(presses);
+    lead    = AQ_SETTIME_NAV_ALLOWANCE + stage;
+    if (target - now >= lead)
+      break;
+    target += 60;
+  }
+
+  *target_out = target;
+  *presses_out = presses;
+  *stage_out = stage;
+  *lead_out = lead;
 }
 
 /*
@@ -249,25 +304,34 @@ unsigned char pop_allb_cmd(struct aqualinkdata *aqdata)
 
 
 
-bool setAqualinkNumericField_ex(struct aqualinkdata *aqdata, char *value_label, int value, int increment, bool sendEnter);
+bool setAqualinkNumericField_ex(struct aqualinkdata *aqdata, char *value_label, int value, int increment, bool sendEnter, time_t deadline);
 bool setAqualinkNumericField(struct aqualinkdata *aqdata, char *value_label, int value)
 {
-  return setAqualinkNumericField_ex(aqdata, value_label, value, 1, true);
+  return setAqualinkNumericField_ex(aqdata, value_label, value, 1, true, 0);
 }
 bool setAqualinkNumericField_new(struct aqualinkdata *aqdata, char *value_label, int value, int increment)
 {
-  return setAqualinkNumericField_ex(aqdata, value_label, value, increment, true);
+  return setAqualinkNumericField_ex(aqdata, value_label, value, increment, true, 0);
+}
+/*
+* As above but give up if 'deadline' (absolute, 0 for none) passes.  The iteration cap
+* below bounds the number of KEYPRESSES, not the time they take, so a panel that answers
+* slowly but keeps answering could otherwise hold a programming menu open for minutes.
+*/
+bool setAqualinkNumericField_until(struct aqualinkdata *aqdata, char *value_label, int value, time_t deadline)
+{
+  return setAqualinkNumericField_ex(aqdata, value_label, value, 1, true, deadline);
 }
 /*
 * Park the field on `value` but leave the ENTER to the caller.  Only useful for the
 * last field of a menu, where that ENTER is what commits the entry and the caller
 * needs to control when that happens (see set_allbutton_time).
 */
-bool setAqualinkNumericField_noenter(struct aqualinkdata *aqdata, char *value_label, int value)
+bool setAqualinkNumericField_noenter(struct aqualinkdata *aqdata, char *value_label, int value, time_t deadline)
 {
-  return setAqualinkNumericField_ex(aqdata, value_label, value, 1, false);
+  return setAqualinkNumericField_ex(aqdata, value_label, value, 1, false, deadline);
 }
-bool setAqualinkNumericField_ex(struct aqualinkdata *aqdata, char *value_label, int value, int increment, bool sendEnter)
+bool setAqualinkNumericField_ex(struct aqualinkdata *aqdata, char *value_label, int value, int increment, bool sendEnter, time_t deadline)
 {
   LOG(ALLB_LOG, LOG_DEBUG,"Setting menu item '%s' to %d\n",value_label, value);
   //char leading[10];  // description of the field (POOL, SPA, FRZ)
@@ -280,6 +344,12 @@ bool setAqualinkNumericField_ex(struct aqualinkdata *aqdata, char *value_label, 
   int i=0;
   do 
   {
+    /* Checked before the wait, so an already-expired deadline returns without touching
+       the panel at all. */
+    if (deadline != 0 && time(0) > deadline) {
+      LOG(ALLB_LOG, LOG_WARNING, "Ran out of time setting '%s' to '%d'\n", value_label, value);
+      return false;
+    }
     if (waitForMessage(aqdata, searchBuf, 4) != true) {
       LOG(ALLB_LOG, LOG_WARNING, "AQ_Programmer Could not set numeric input '%s', not found\n",value_label);
       cancel_menu();
@@ -1284,7 +1354,7 @@ static bool parse_hour_menu(const char *msg, int *hour24)
 * to 12 AM, so any hour is reachable in at most 23 presses.  KEY_LEFT would halve the
 * worst case but is unverified on this field, and guessing wrong here sets the clock wrong.
 */
-static bool setAqualinkHourField(struct aqualinkdata *aqdata, int hour24)
+static bool setAqualinkHourField(struct aqualinkdata *aqdata, int hour24, time_t deadline)
 {
   char target[20];
   char expect[20];
@@ -1292,6 +1362,15 @@ static bool setAqualinkHourField(struct aqualinkdata *aqdata, int hour24)
   int i = 0;
 
   hour_menu_string(target, sizeof(target), hour24);
+
+  /* Before the first wait, so an already-expired deadline gives up without blocking.
+     NOTE this cannot interrupt a wait already in progress: waitForMessage() uses
+     pthread_cond_wait() with no timeout, so a panel that goes completely silent still
+     parks the thread. Bounding that needs pthread_cond_timedwait() throughout. */
+  if (deadline != 0 && time(0) > deadline) {
+    LOG(ALLB_LOG, LOG_WARNING, "Ran out of time before setting the panel hour to '%s'\n", target);
+    return false;
+  }
 
   /* Get a real HOUR line before deciding anything, the last message is still the DAY
      field at this point. */
@@ -1301,6 +1380,10 @@ static bool setAqualinkHourField(struct aqualinkdata *aqdata, int hour24)
   }
 
   while (i++ <= 24) {
+    if (deadline != 0 && time(0) > deadline) {
+      LOG(ALLB_LOG, LOG_WARNING, "Ran out of time setting the panel hour to '%s'\n", target);
+      return false;
+    }
     if ( parse_hour_menu(aqdata->last_message, &cur24) != true ) {
       LOG(ALLB_LOG, LOG_WARNING, "Could not read panel hour from '%s'\n", aqdata->last_message);
       return false;
@@ -1340,6 +1423,7 @@ void *set_allbutton_time( void *ptr )
   char buf[40];
   int lead, stage_secs, presses, i;
   int panel_offset_at_start, would_be_slow;
+  time_t stage_deadline;
 
   /* The SET TIME menu has no seconds field, the panel starts its clock at HH:MM:00 the
      moment the entry is committed.  So the accuracy of the sync is decided by *when* we
@@ -1366,22 +1450,9 @@ void *set_allbutton_time( void *ptr )
   now = time(0);                                     // slot acquisition may have blocked
   panel_offset_at_start = settime_panel_offset(aqdata, now);
 
-  /* Derive how long staging will take from what the panel is showing, then pick the first
+  /* Derive how long staging will take from what the panel is showing, and pick the first
      boundary that leaves room for the menu walk plus that staging. */
-  target = now;
-  for (i = 0; i < 2; i++) {
-    /* Two passes: the press count depends on the target minute, which depends on the
-       press count. One refinement is enough - a minute either way changes the MINUTE
-       field by at most one press. */
-    localtime_r(&target, &tm_target);
-    presses = (i == 0) ? AQ_SETTIME_PRESSES_MAX
-                       : settime_expected_presses(aqdata, &tm_target);
-    stage_secs = settime_stage_secs(presses);
-    lead = AQ_SETTIME_NAV_ALLOWANCE + stage_secs;
-    target = ((now + lead) / 60) * 60;               // boundary at or before now+lead
-    if (target < now + lead)
-      target += 60;                                  // first boundary at or after
-  }
+  settime_plan(aqdata, now, &target, &presses, &stage_secs, &lead);
   localtime_r(&target, &tm_target);
 
   /* Wait out here, before the menu is opened, so the panel is not sat in a programming
@@ -1425,43 +1496,58 @@ void *set_allbutton_time( void *ptr )
      becomes the better answer. */
   now = time(0);
   if (target - now < stage_secs) {
-    if (target + 60 - now < stage_secs) {
-      LOG(ALLB_LOG, LOG_ERR, "Menu walk left only %ds before %s, not enough for %ds of staging. Abandoning\n",
-          (int)(target - now), buf, stage_secs);
+    /* Step out a minute at a time, recomputing the cost for each candidate.  The numeric
+       fields do not wrap, so the next boundary is NOT simply one press further away -
+       from a panel showing 12:58 a 12:59 target costs 1 press and 13:00 costs 58, about
+       20 seconds more.  Reusing the old figure here would accept a boundary that staging
+       cannot reach, and would also hand the field setters a deadline far too tight. */
+    for (i = 0; i < 2 && target - now < stage_secs; i++) {
+      target += 60;
+      localtime_r(&target, &tm_target);
+      presses = settime_expected_presses(aqdata, &tm_target);
+      stage_secs = settime_stage_secs(presses);
+    }
+    if (target - now < stage_secs) {
+      LOG(ALLB_LOG, LOG_ERR, "Menu walk ran long, and no reachable boundary needs less than %ds of staging. Abandoning\n",
+          stage_secs);
       goto settime_failed;
     }
-    target += 60;
-    localtime_r(&target, &tm_target);
     hour_menu_string(hour, sizeof(hour), tm_target.tm_hour);
     strftime(buf, sizeof(buf), "%m/%d/%y %I:%M %p", &tm_target);
-    LOG(ALLB_LOG, LOG_NOTICE, "Menu walk ran long, retargeting to %s ('%s')\n", buf, hour);
+    LOG(ALLB_LOG, LOG_NOTICE, "Menu walk ran long, retargeting to %s ('%s'), %d presses / %ds staging\n",
+        buf, hour, presses, stage_secs);
   }
+
+  /* Bound the staging itself.  stage_secs is derived at 350ms/press against a measured
+     264ms, so it already carries headroom; the slack covers a panel that is simply
+     slower than this one. */
+  stage_deadline = now + stage_secs + AQ_SETTIME_DEADLINE_SLACK;
 
   /* Every field is checked.  Getting any of them wrong silently sets the panel clock
      wrong, and for MINUTE it is worse than that: on failure the helper has already
      cancelled the menu, so carrying on would wait for the boundary and then fire two
      ENTERs into whatever the panel is showing by then. */
-  if ( setAqualinkNumericField(aqdata, "YEAR", tm_target.tm_year + 1900) != true ) {
+  if ( setAqualinkNumericField_until(aqdata, "YEAR", tm_target.tm_year + 1900, stage_deadline) != true ) {
     LOG(ALLB_LOG, LOG_ERR, "Could not set panel year, abandoning panel time set\n");
     goto settime_failed;
   }
-  if ( setAqualinkNumericField(aqdata, "MONTH", tm_target.tm_mon + 1) != true ) {
+  if ( setAqualinkNumericField_until(aqdata, "MONTH", tm_target.tm_mon + 1, stage_deadline) != true ) {
     LOG(ALLB_LOG, LOG_ERR, "Could not set panel month, abandoning panel time set\n");
     goto settime_failed;
   }
-  if ( setAqualinkNumericField(aqdata, "DAY", tm_target.tm_mday) != true ) {
+  if ( setAqualinkNumericField_until(aqdata, "DAY", tm_target.tm_mday, stage_deadline) != true ) {
     LOG(ALLB_LOG, LOG_ERR, "Could not set panel day, abandoning panel time set\n");
     goto settime_failed;
   }
   //setAqualinkNumericFieldExtra(aqdata, "HOUR", 11, "PM");
   /* See setAqualinkHourField() for why this does not use select_sub_menu_item(). */
-  if ( setAqualinkHourField(aqdata, tm_target.tm_hour) != true ) {
+  if ( setAqualinkHourField(aqdata, tm_target.tm_hour, stage_deadline) != true ) {
     LOG(ALLB_LOG, LOG_ERR, "Could not set panel hour to '%s', abandoning panel time set\n", hour);
     goto settime_failed;
   }
   // MINUTE is the last field, so its ENTER is the one that commits.  Park the field on
   // the target minute but keep hold of that keypress.
-  if ( setAqualinkNumericField_noenter(aqdata, "MINUTE", tm_target.tm_min) != true ) {
+  if ( setAqualinkNumericField_noenter(aqdata, "MINUTE", tm_target.tm_min, stage_deadline) != true ) {
     LOG(ALLB_LOG, LOG_ERR, "Could not set panel minute, abandoning panel time set\n");
     goto settime_failed;
   }

--- a/source/allbutton_aq_programmer.c
+++ b/source/allbutton_aq_programmer.c
@@ -5,6 +5,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <time.h>
+#include <limits.h>
 
 #include "aqualink.h"
 #include "allbutton_aq_programmer.h"
@@ -39,12 +40,103 @@ void longwaitfor_queue2empty();
 * one.  The wait happens BEFORE the menu is opened, so the panel is not held in a
 * programming menu, and neither is AqualinkD's programming thread.
 */
-#define AQ_SETTIME_WALK_MARGIN   8   /* slack added to the remembered walk duration */
-#define AQ_SETTIME_WALK_DEFAULT 20   /* first guess, before we have ever measured one */
-#define AQ_SETTIME_WALK_MIN     10   /* never trust an estimate shorter than this */
-#define AQ_SETTIME_WALK_MAX     90   /* do not let a pathological walk push the lead out */
+/*
+* How long the staging takes is not guessed and not learned from a previous run - it is
+* DERIVED.  Both field setters step one unit per keypress with no wraparound, so the
+* number of presses is known from what the panel is currently displaying:
+*   numeric field: |target - current|      hour field: (target - current + 24) % 24
+* A learned duration is wrong exactly when it matters: a run where every field already
+* matched measures ~1s, and the next run after a power loss needs over 100 presses.
+*/
+#define AQ_SETTIME_PRESS_MS     350  /* per keypress; measured 264ms, rounded up */
+#define AQ_SETTIME_STAGE_BASE     3  /* fixed cost of staging, on top of the presses */
+#define AQ_SETTIME_NAV_ALLOWANCE 12  /* menu walk to SET TIME; measured 3.5s, retries x3 */
+#define AQ_SETTIME_PRESSES_MAX  140  /* used when the panel display cannot be parsed */
 
-static int _settime_walk_secs = AQ_SETTIME_WALK_DEFAULT;
+/*
+* Read the date and time the panel is currently displaying, e.g. "09/04/26 FRI" and
+* "5:57 PM".  Only the fields the SET TIME menu can change are filled in.
+*/
+static bool panel_display_to_tm(struct aqualinkdata *aqdata, struct tm *out)
+{
+  int mon, mday, yr, h12, min;
+  char mer[4];
+
+  if (sscanf(aqdata->date, "%d/%d/%d", &mon, &mday, &yr) != 3)
+    return false;
+  if (sscanf(aqdata->time, "%d:%d %3s", &h12, &min, mer) != 3)
+    return false;
+  if (mon < 1 || mon > 12 || mday < 1 || mday > 31 || h12 < 1 || h12 > 12 || min < 0 || min > 59)
+    return false;
+
+  memset(out, 0, sizeof(*out));
+  out->tm_year = yr + 100;                       /* panel shows a 2 digit year */
+  out->tm_mon  = mon - 1;
+  out->tm_mday = mday;
+  out->tm_min  = min;
+  if (mer[0] == 'A' || mer[0] == 'a')
+    out->tm_hour = (h12 == 12) ? 0 : h12;
+  else if (mer[0] == 'P' || mer[0] == 'p')
+    out->tm_hour = (h12 == 12) ? 12 : h12 + 12;
+  else
+    return false;
+
+  return true;
+}
+
+/*
+* Keypresses needed to stage every field for 'tgt', from where the panel is now.
+* Includes the ENTER that accepts each of the first four fields.
+*/
+static int settime_expected_presses(struct aqualinkdata *aqdata, const struct tm *tgt)
+{
+  struct tm cur;
+  int presses;
+
+  if (! panel_display_to_tm(aqdata, &cur)) {
+    LOG(ALLB_LOG, LOG_WARNING, "Could not read panel date/time ('%s' '%s'), assuming a worst case walk\n",
+        aqdata->date, aqdata->time);
+    return AQ_SETTIME_PRESSES_MAX;
+  }
+
+  presses  = abs(tgt->tm_year - cur.tm_year);
+  presses += abs(tgt->tm_mon  - cur.tm_mon);
+  presses += abs(tgt->tm_mday - cur.tm_mday);
+  presses += (tgt->tm_hour - cur.tm_hour + 24) % 24;   /* hour is RIGHT only, so it wraps */
+  presses += abs(tgt->tm_min  - cur.tm_min);
+  presses += 4;                                        /* ENTER after YEAR/MONTH/DAY/HOUR */
+
+  return presses;
+}
+
+/* Seconds the staging is expected to need for 'presses' keypresses. */
+static int settime_stage_secs(int presses)
+{
+  return AQ_SETTIME_STAGE_BASE + ((presses * AQ_SETTIME_PRESS_MS) + 999) / 1000;
+}
+
+/*
+* How far the panel clock is behind system time right now, in seconds, from what it is
+* displaying.  Coarse (the display has no seconds, so this is the minute midpoint,
+* +/-30s) but it only has to answer "would committing late still be an improvement".
+* INT_MAX when the display cannot be read, which makes any commit look like a win.
+*/
+static int settime_panel_offset(struct aqualinkdata *aqdata, time_t now)
+{
+  struct tm cur;
+  time_t panel;
+
+  if (! panel_display_to_tm(aqdata, &cur))
+    return INT_MAX;
+
+  cur.tm_sec = 30;                       /* midpoint of the minute it is showing */
+  cur.tm_isdst = localtime(&now)->tm_isdst;
+  panel = mktime(&cur);
+  if (panel == (time_t)-1)
+    return INT_MAX;
+
+  return abs((int)(now - panel));
+}
 
 /*
 * Sleep until 'until', bailing out early if AqualinkD is shutting down.
@@ -1242,11 +1334,12 @@ void *set_allbutton_time( void *ptr )
   struct aqualinkdata *aqdata = threadCtrl->aqdata;
   
   time_t now;             // read after the programming slot is claimed, see below
-  time_t target, walk_start;
+  time_t target;
   struct tm tm_target;
   char hour[20];
   char buf[40];
-  int lead, walked;
+  int lead, stage_secs, presses, i;
+  int panel_offset_at_start, would_be_slow;
 
   /* The SET TIME menu has no seconds field, the panel starts its clock at HH:MM:00 the
      moment the entry is committed.  So the accuracy of the sync is decided by *when* we
@@ -1271,25 +1364,37 @@ void *set_allbutton_time( void *ptr )
   waitForSingleThreadOrTerminate(threadCtrl, AQ_SET_TIME);
 
   now = time(0);                                     // slot acquisition may have blocked
-  lead = _settime_walk_secs + AQ_SETTIME_WALK_MARGIN;
-  target = ((now + lead) / 60) * 60;                 // boundary at or before now+lead
-  if (target < now + lead)
-    target += 60;                                    // first boundary at or after
+  panel_offset_at_start = settime_panel_offset(aqdata, now);
+
+  /* Derive how long staging will take from what the panel is showing, then pick the first
+     boundary that leaves room for the menu walk plus that staging. */
+  target = now;
+  for (i = 0; i < 2; i++) {
+    /* Two passes: the press count depends on the target minute, which depends on the
+       press count. One refinement is enough - a minute either way changes the MINUTE
+       field by at most one press. */
+    localtime_r(&target, &tm_target);
+    presses = (i == 0) ? AQ_SETTIME_PRESSES_MAX
+                       : settime_expected_presses(aqdata, &tm_target);
+    stage_secs = settime_stage_secs(presses);
+    lead = AQ_SETTIME_NAV_ALLOWANCE + stage_secs;
+    target = ((now + lead) / 60) * 60;               // boundary at or before now+lead
+    if (target < now + lead)
+      target += 60;                                  // first boundary at or after
+  }
+  localtime_r(&target, &tm_target);
 
   /* Wait out here, before the menu is opened, so the panel is not sat in a programming
-     menu (where it may time out on its own) for any longer than the walk needs. */
-  if (target - now > AQ_SETTIME_WALK_MARGIN) {
-    LOG(ALLB_LOG, LOG_DEBUG, "Waiting %d seconds before opening SET TIME menu (last walk took %ds)\n",
-        (int)(target - now - _settime_walk_secs), _settime_walk_secs);
-    if (! settime_wait_until(target - _settime_walk_secs)) {
+     menu (where it may time out on its own) for any longer than the work needs. */
+  if (target - now > lead) {
+    LOG(ALLB_LOG, LOG_DEBUG, "Waiting %d seconds before opening SET TIME menu (%d presses, %ds staging)\n",
+        (int)(target - now - lead), presses, stage_secs);
+    if (! settime_wait_until(target - lead)) {
       LOG(ALLB_LOG, LOG_WARNING, "Shutting down, abandoning panel time set\n");
       cleanAndTerminateThread(threadCtrl);
       return ptr;
     }
   }
-  walk_start = time(0);
-
-  localtime_r(&target, &tm_target);
 
   hour_menu_string(hour, sizeof(hour), tm_target.tm_hour);
 
@@ -1310,6 +1415,28 @@ void *set_allbutton_time( void *ptr )
     return ptr;
   }
   
+  /* SET TIME is confirmed, so the panel is showing YEAR and the accuracy sensitive part
+     starts here.  Navigation is the variable bit (select_menu_item() retries up to three
+     times), so re-check that the boundary is still reachable before staging anything -
+     that is what keeps the menu walk out of the timing calculation.
+     A missed boundary is retargeted one minute rather than cancelled: checkAqualinkTime()
+     is rate limited to once an hour, so cancelling here would mean no retry until then.
+     Once out of tolerance observations are coalesced into a pending request, cancelling
+     becomes the better answer. */
+  now = time(0);
+  if (target - now < stage_secs) {
+    if (target + 60 - now < stage_secs) {
+      LOG(ALLB_LOG, LOG_ERR, "Menu walk left only %ds before %s, not enough for %ds of staging. Abandoning\n",
+          (int)(target - now), buf, stage_secs);
+      goto settime_failed;
+    }
+    target += 60;
+    localtime_r(&target, &tm_target);
+    hour_menu_string(hour, sizeof(hour), tm_target.tm_hour);
+    strftime(buf, sizeof(buf), "%m/%d/%y %I:%M %p", &tm_target);
+    LOG(ALLB_LOG, LOG_NOTICE, "Menu walk ran long, retargeting to %s ('%s')\n", buf, hour);
+  }
+
   /* Every field is checked.  Getting any of them wrong silently sets the panel clock
      wrong, and for MINUTE it is worse than that: on failure the helper has already
      cancelled the menu, so carrying on would wait for the boundary and then fire two
@@ -1339,19 +1466,6 @@ void *set_allbutton_time( void *ptr )
     goto settime_failed;
   }
 
-  /* Remember how long that took so the next sync knows when to start.  Rise immediately
-     but decay only a second per sync: a walk where every field already matched measures
-     about 4s, and letting the estimate collapse to that would make the next hard walk
-     (up to 23 hour presses plus 59 minute presses, ~0.26s each) overrun the boundary. */
-  walked = (int)(time(0) - walk_start);
-  if (walked < 1) walked = 1;
-  if (walked > _settime_walk_secs)
-    _settime_walk_secs = walked;
-  else if (_settime_walk_secs > AQ_SETTIME_WALK_MIN)
-    _settime_walk_secs--;
-  if (_settime_walk_secs < AQ_SETTIME_WALK_MIN) _settime_walk_secs = AQ_SETTIME_WALK_MIN;
-  if (_settime_walk_secs > AQ_SETTIME_WALK_MAX) _settime_walk_secs = AQ_SETTIME_WALK_MAX;
-
   if (! settime_wait_until(target)) {
     LOG(ALLB_LOG, LOG_WARNING, "Shutting down, abandoning panel time set\n");
     cancel_menu();
@@ -1361,13 +1475,18 @@ void *set_allbutton_time( void *ptr )
 
   now = time(0);
   if (now > target) {
-    // The walk took longer than the lead we allowed. Commit anyway and let
-    // checkAqualinkTime() retry; _settime_walk_secs has just been updated with the real
-    // duration, so the retry will start early enough.
-    LOG(ALLB_LOG, LOG_WARNING, "SET TIME walk took %ds and overran the target by %ds, panel will be slow. Will re-check on next cycle\n",
-        walked, (int)(now - target));
-  } else {
-    LOG(ALLB_LOG, LOG_DEBUG, "SET TIME walk took %ds, committing on the boundary\n", walked);
+    /* We missed the boundary, so committing now would set the panel that many seconds
+       slow on purpose.  Only do it if it still beats where the panel already is -
+       otherwise cancel and let checkAqualinkTime() try again rather than knowingly
+       writing a stale time. */
+    would_be_slow = (int)(now - target);
+    if (would_be_slow >= panel_offset_at_start) {
+      LOG(ALLB_LOG, LOG_WARNING, "Overran the target by %ds, which is no better than the %ds the panel is already out. Cancelling, will re-check on next cycle\n",
+          would_be_slow, panel_offset_at_start);
+      goto settime_failed;
+    }
+    LOG(ALLB_LOG, LOG_WARNING, "Overran the target by %ds, committing anyway as the panel is currently %ds out\n",
+        would_be_slow, panel_offset_at_start);
   }
 
   send_cmd(KEY_ENTER); // Accept the MINUTE field, this is what starts the panel clock.

--- a/source/allbutton_aq_programmer.c
+++ b/source/allbutton_aq_programmer.c
@@ -4,6 +4,7 @@
 #include <pthread.h>
 #include <unistd.h>
 #include <string.h>
+#include <time.h>
 
 #include "aqualink.h"
 #include "allbutton_aq_programmer.h"
@@ -27,6 +28,37 @@ void cancel_menu();
 
 void waitfor_queue2empty();
 void longwaitfor_queue2empty();
+
+/*
+* set_allbutton_time() commits the panel clock on a minute boundary, because the panel has
+* no seconds field and starts counting from HH:MM:00 the instant the entry is committed.
+*
+* The menu walk has to FINISH just before that boundary.  We do not know up front how long
+* it takes (the MINUTE field is one keypress per minute of travel, up to 59 of them), so
+* the duration of the last walk is remembered and used to decide when to start the next
+* one.  The wait happens BEFORE the menu is opened, so the panel is not held in a
+* programming menu, and neither is AqualinkD's programming thread.
+*/
+#define AQ_SETTIME_WALK_MARGIN   8   /* slack added to the remembered walk duration */
+#define AQ_SETTIME_WALK_DEFAULT 20   /* first guess, before we have ever measured one */
+#define AQ_SETTIME_WALK_MIN     10   /* never trust an estimate shorter than this */
+#define AQ_SETTIME_WALK_MAX     90   /* do not let a pathological walk push the lead out */
+
+static int _settime_walk_secs = AQ_SETTIME_WALK_DEFAULT;
+
+/*
+* Sleep until 'until', bailing out early if AqualinkD is shutting down.
+* Returns false if we gave up because of a shutdown.
+*/
+static bool settime_wait_until(time_t until)
+{
+  while (time(0) < until) {
+    if (isAqualinkDStopping())
+      return false;
+    delay(100);
+  }
+  return true;
+}
 
 int _expectNextMessage = 0;
 unsigned char _allb_last_sent_command = NUL;
@@ -125,12 +157,25 @@ unsigned char pop_allb_cmd(struct aqualinkdata *aqdata)
 
 
 
-bool setAqualinkNumericField_new(struct aqualinkdata *aqdata, char *value_label, int value, int increment);
+bool setAqualinkNumericField_ex(struct aqualinkdata *aqdata, char *value_label, int value, int increment, bool sendEnter);
 bool setAqualinkNumericField(struct aqualinkdata *aqdata, char *value_label, int value)
 {
-  return setAqualinkNumericField_new(aqdata, value_label, value, 1);
+  return setAqualinkNumericField_ex(aqdata, value_label, value, 1, true);
 }
 bool setAqualinkNumericField_new(struct aqualinkdata *aqdata, char *value_label, int value, int increment)
+{
+  return setAqualinkNumericField_ex(aqdata, value_label, value, increment, true);
+}
+/*
+* Park the field on `value` but leave the ENTER to the caller.  Only useful for the
+* last field of a menu, where that ENTER is what commits the entry and the caller
+* needs to control when that happens (see set_allbutton_time).
+*/
+bool setAqualinkNumericField_noenter(struct aqualinkdata *aqdata, char *value_label, int value)
+{
+  return setAqualinkNumericField_ex(aqdata, value_label, value, 1, false);
+}
+bool setAqualinkNumericField_ex(struct aqualinkdata *aqdata, char *value_label, int value, int increment, bool sendEnter)
 {
   LOG(ALLB_LOG, LOG_DEBUG,"Setting menu item '%s' to %d\n",value_label, value);
   //char leading[10];  // description of the field (POOL, SPA, FRZ)
@@ -165,14 +210,17 @@ bool setAqualinkNumericField_new(struct aqualinkdata *aqdata, char *value_label,
       send_cmd(KEY_LEFT);
     }
     else {
-      // Just send ENTER. We are at the right value.
+      // We are at the right value.  Send ENTER to accept it, unless the caller asked
+      // to keep hold of that keypress.
       sprintf(searchBuf, "%s %d", value_label, current_val);
-      send_cmd(KEY_ENTER);
+      if (sendEnter)
+        send_cmd(KEY_ENTER);
     }
 
     if (i++ >= 100) {
       LOG(ALLB_LOG, LOG_WARNING, "AQ_Programmer Could not set numeric input '%s', to '%d'\n",value_label,value);
-      send_cmd(KEY_ENTER);
+      if (sendEnter)
+        send_cmd(KEY_ENTER);
       break;
     }
   } while(value != current_val); 
@@ -1082,36 +1130,167 @@ void *set_allbutton_freeze_heater_temps( void *ptr )
   return ptr;
 }
 
+/*
+* Build the SET TIME menu's HOUR line for a 0-23 hour, e.g. 16 -> "HOUR 4 PM".
+*/
+static void hour_menu_string(char *out, size_t size, int hour24)
+{
+  if (hour24 == 0)
+    snprintf(out, size, "HOUR 12 AM");
+  else if (hour24 <= 11)
+    snprintf(out, size, "HOUR %d AM", hour24);
+  else if (hour24 == 12)
+    snprintf(out, size, "HOUR 12 PM");
+  else
+    snprintf(out, size, "HOUR %d PM", hour24 - 12);
+}
+
+/*
+* Read a 0-23 hour back out of a panel HOUR line. false if it is not one.
+*/
+static bool parse_hour_menu(const char *msg, int *hour24)
+{
+  char *p = stristr(msg, "HOUR");
+  int h12;
+  char mer[4];
+
+  if (p == NULL)
+    return false;
+  if (sscanf(p, "%*s %d %3s", &h12, mer) != 2)
+    return false;
+  if (h12 < 1 || h12 > 12)
+    return false;
+
+  if (mer[0] == 'A' || mer[0] == 'a')
+    *hour24 = (h12 == 12) ? 0 : h12;
+  else if (mer[0] == 'P' || mer[0] == 'p')
+    *hour24 = (h12 == 12) ? 12 : h12 + 12;
+  else
+    return false;
+
+  return true;
+}
+
+/*
+* Set the SET TIME menu's HOUR field, leaving the panel on the next field.
+*
+* Neither of the generic helpers is safe here.  setAqualinkNumericField() cannot parse a
+* field with a meridiem on it, and select_sub_menu_item() waits only for the FINAL target
+* string, which loses a race the panel wins every time: coming out of the DAY field the
+* last message received is still the DAY line, so its opening comparison fails, it presses
+* RIGHT before it has ever seen the hour, and then matches the pre-keypress "HOUR n xM"
+* the panel had already queued - committing an hour too far.  That is where the "panel is
+* an hour ahead" came from.
+*
+* So do what setAqualinkNumericField() does and wait for the specific value the keypress
+* we just sent should produce.  Every step re-reads the field, so a stale or buffered
+* message cannot make us lose count.
+*
+* Only KEY_RIGHT is used.  It is the proven direction for this field and wraps 11 PM round
+* to 12 AM, so any hour is reachable in at most 23 presses.  KEY_LEFT would halve the
+* worst case but is unverified on this field, and guessing wrong here sets the clock wrong.
+*/
+static bool setAqualinkHourField(struct aqualinkdata *aqdata, int hour24)
+{
+  char target[20];
+  char expect[20];
+  int cur24 = -1;
+  int i = 0;
+
+  hour_menu_string(target, sizeof(target), hour24);
+
+  /* Get a real HOUR line before deciding anything, the last message is still the DAY
+     field at this point. */
+  if ( waitForMessage(aqdata, "HOUR", 4) != true ) {
+    LOG(ALLB_LOG, LOG_WARNING, "Never saw the HOUR field on the panel\n");
+    return false;
+  }
+
+  while (i++ <= 24) {
+    if ( parse_hour_menu(aqdata->last_message, &cur24) != true ) {
+      LOG(ALLB_LOG, LOG_WARNING, "Could not read panel hour from '%s'\n", aqdata->last_message);
+      return false;
+    }
+
+    if (cur24 == hour24) {
+      LOG(ALLB_LOG, LOG_DEBUG, "Panel hour is '%s', accepting\n", target);
+      send_cmd(KEY_ENTER);
+      waitForMessage(aqdata, NULL, 1); // let the panel move to the next field
+      return true;
+    }
+
+    hour_menu_string(expect, sizeof(expect), (cur24 + 1) % 24);
+    LOG(ALLB_LOG, LOG_DEBUG, "Stepping panel hour to '%s' (want '%s')\n", expect, target);
+    send_cmd(KEY_RIGHT);
+    waitfor_queue2empty();
+    if ( waitForMessage(aqdata, expect, 4) != true ) {
+      LOG(ALLB_LOG, LOG_WARNING, "Panel hour did not step to '%s'\n", expect);
+      return false;
+    }
+  }
+
+  LOG(ALLB_LOG, LOG_WARNING, "Gave up stepping panel hour to '%s'\n", target);
+  return false;
+}
+
 void *set_allbutton_time( void *ptr )
 {
   struct programmingThreadCtrl *threadCtrl;
   threadCtrl = (struct programmingThreadCtrl *) ptr;
   struct aqualinkdata *aqdata = threadCtrl->aqdata;
   
-  waitForSingleThreadOrTerminate(threadCtrl, AQ_SET_TIME);
-  //LOG(ALLB_LOG, LOG_NOTICE, "Setting time on aqualink\n");
-
   time_t now = time(0);   // get time now
-  struct tm *result = localtime(&now);
+  time_t target, walk_start;
+  struct tm tm_target;
   char hour[20];
+  char buf[40];
+  int lead, walked;
 
-  // Add 10 seconds to time since this can take a while to program.
-  // 10 to 20 seconds whould be right, but since there are no seconds we can set, add 30 seconds to get close to minute.
-  // Should probably set this to program the next minute then wait before hitting the final enter command.
-  result->tm_sec += 30;
-  mktime(result);
-  
-  if (result->tm_hour == 0)
-    sprintf(hour, "HOUR 12 AM");
-  else if (result->tm_hour <= 11)
-    sprintf(hour, "HOUR %d AM", result->tm_hour); // Need to fix compiler warning on new GCC, but %2d or %.2d does NOT give correct string
-  else if (result->tm_hour == 12)
-    sprintf(hour, "HOUR 12 PM");
-  else // Must be 13 or more
-    sprintf(hour, "HOUR %d PM", result->tm_hour - 12);
-  
+  /* The SET TIME menu has no seconds field, the panel starts its clock at HH:MM:00 the
+     moment the entry is committed.  So the accuracy of the sync is decided by *when* we
+     press the final ENTER, not by how cleverly we round the minute we type in.
 
-  LOG(ALLB_LOG, LOG_DEBUG, "Setting time to %d/%d/%d %d:%d\n", result->tm_mon + 1, result->tm_mday, result->tm_year + 1900, result->tm_hour + 1, result->tm_min);
+     Programming is slow.  Every digit is a keypress that has to round trip through the
+     panel display, and the MINUTE field can be up to 59 presses away from where it
+     starts.  Reading the clock up front and adding a fixed 30 seconds (what we used to
+     do) therefore left the panel behind by however long the programming happened to
+     take, which is where the "panel is always about a minute slow" came from.
+
+     So: pick the minute boundary we will commit on, wait out here until it is nearly
+     time, and only then open the menu and walk the fields.  Waiting before we open the
+     menu means the panel is not sat in a programming menu for a minute (where it may
+     time out on its own), and the programming thread is not claimed either, so anything
+     else AqualinkD wants to do can still get through. */
+  lead = _settime_walk_secs + AQ_SETTIME_WALK_MARGIN;
+  target = ((now + lead) / 60) * 60;                 // boundary at or before now+lead
+  if (target < now + lead)
+    target += 60;                                    // first boundary at or after
+
+  if (target - now > AQ_SETTIME_WALK_MARGIN) {
+    LOG(ALLB_LOG, LOG_DEBUG, "Waiting %d seconds before opening SET TIME menu (last walk took %ds)\n",
+        (int)(target - now - _settime_walk_secs), _settime_walk_secs);
+    if (! settime_wait_until(target - _settime_walk_secs)) {
+      LOG(ALLB_LOG, LOG_WARNING, "Shutting down, abandoning panel time set\n");
+      cleanAndTerminateThread(threadCtrl);
+      return ptr;
+    }
+  }
+
+  waitForSingleThreadOrTerminate(threadCtrl, AQ_SET_TIME);
+  walk_start = time(0);
+
+  localtime_r(&target, &tm_target);
+
+  hour_menu_string(hour, sizeof(hour), tm_target.tm_hour);
+
+  strftime(buf, sizeof(buf), "%m/%d/%y %I:%M %p", &tm_target);
+  // NOTICE, not INFO: the companion "Time is NOT accurate" line is NOTICE, and with this
+  // at INFO the one line that says what we actually sent the panel was invisible at the
+  // default log level.  '%s' is the literal hour menu string, so a wrong hour is obvious.
+  // Re-read the clock: 'now' was taken before the pre-wait, so using it here reported the
+  // countdown from when the thread started rather than from now.
+  LOG(ALLB_LOG, LOG_NOTICE, "Setting panel time to %s ('%s'), committing in %d seconds\n",
+      buf, hour, (int)(target - time(0)));
 
   if ( select_menu_item(aqdata, "SET TIME") != true ) {
     LOG(ALLB_LOG, LOG_WARNING, "Could not select SET TIME menu\n");
@@ -1121,14 +1300,55 @@ void *set_allbutton_time( void *ptr )
     return ptr;
   }
   
-  setAqualinkNumericField(aqdata, "YEAR", result->tm_year + 1900);
-  setAqualinkNumericField(aqdata, "MONTH", result->tm_mon + 1);
-  setAqualinkNumericField(aqdata, "DAY", result->tm_mday);
+  setAqualinkNumericField(aqdata, "YEAR", tm_target.tm_year + 1900);
+  setAqualinkNumericField(aqdata, "MONTH", tm_target.tm_mon + 1);
+  setAqualinkNumericField(aqdata, "DAY", tm_target.tm_mday);
   //setAqualinkNumericFieldExtra(aqdata, "HOUR", 11, "PM");
-  select_sub_menu_item(aqdata, hour); // This will keep looping until it finds the right message
-  setAqualinkNumericField(aqdata, "MINUTE", result->tm_min);
-  
-  send_cmd(KEY_ENTER);
+  /* Getting the hour wrong silently sets the panel clock wrong, so this one is neither
+     ignored nor left to select_sub_menu_item(). See setAqualinkHourField(). */
+  if ( setAqualinkHourField(aqdata, tm_target.tm_hour) != true ) {
+    LOG(ALLB_LOG, LOG_ERR, "Could not set panel hour to '%s', abandoning panel time set\n", hour);
+    cancel_menu();
+    cleanAndTerminateThread(threadCtrl);
+    return ptr;
+  }
+  // MINUTE is the last field, so its ENTER is the one that commits.  Park the field on
+  // the target minute but keep hold of that keypress.
+  setAqualinkNumericField_noenter(aqdata, "MINUTE", tm_target.tm_min);
+
+  /* Remember how long that took so the next sync knows when to start.  Rise immediately
+     but decay only a second per sync: a walk where every field already matched measures
+     about 4s, and letting the estimate collapse to that would make the next hard walk
+     (up to 23 hour presses plus 59 minute presses, ~0.26s each) overrun the boundary. */
+  walked = (int)(time(0) - walk_start);
+  if (walked < 1) walked = 1;
+  if (walked > _settime_walk_secs)
+    _settime_walk_secs = walked;
+  else if (_settime_walk_secs > AQ_SETTIME_WALK_MIN)
+    _settime_walk_secs--;
+  if (_settime_walk_secs < AQ_SETTIME_WALK_MIN) _settime_walk_secs = AQ_SETTIME_WALK_MIN;
+  if (_settime_walk_secs > AQ_SETTIME_WALK_MAX) _settime_walk_secs = AQ_SETTIME_WALK_MAX;
+
+  if (! settime_wait_until(target)) {
+    LOG(ALLB_LOG, LOG_WARNING, "Shutting down, abandoning panel time set\n");
+    cancel_menu();
+    cleanAndTerminateThread(threadCtrl);
+    return ptr;
+  }
+
+  now = time(0);
+  if (now > target) {
+    // The walk took longer than the lead we allowed. Commit anyway and let
+    // checkAqualinkTime() retry; _settime_walk_secs has just been updated with the real
+    // duration, so the retry will start early enough.
+    LOG(ALLB_LOG, LOG_WARNING, "SET TIME walk took %ds and overran the target by %ds, panel will be slow. Will re-check on next cycle\n",
+        walked, (int)(now - target));
+  } else {
+    LOG(ALLB_LOG, LOG_DEBUG, "SET TIME walk took %ds, committing on the boundary\n", walked);
+  }
+
+  send_cmd(KEY_ENTER); // Accept the MINUTE field, this is what starts the panel clock.
+  send_cmd(KEY_ENTER); // Commit / leave the SET TIME menu.
 
   cleanAndTerminateThread(threadCtrl);
   

--- a/source/allbutton_aq_programmer.c
+++ b/source/allbutton_aq_programmer.c
@@ -221,7 +221,9 @@ bool setAqualinkNumericField_ex(struct aqualinkdata *aqdata, char *value_label, 
       LOG(ALLB_LOG, LOG_WARNING, "AQ_Programmer Could not set numeric input '%s', to '%d'\n",value_label,value);
       if (sendEnter)
         send_cmd(KEY_ENTER);
-      break;
+      // Was 'break', which then fell through to 'return true' and reported a field we
+      // never managed to set as successful.
+      return false;
     }
   } while(value != current_val); 
   
@@ -1308,21 +1310,34 @@ void *set_allbutton_time( void *ptr )
     return ptr;
   }
   
-  setAqualinkNumericField(aqdata, "YEAR", tm_target.tm_year + 1900);
-  setAqualinkNumericField(aqdata, "MONTH", tm_target.tm_mon + 1);
-  setAqualinkNumericField(aqdata, "DAY", tm_target.tm_mday);
+  /* Every field is checked.  Getting any of them wrong silently sets the panel clock
+     wrong, and for MINUTE it is worse than that: on failure the helper has already
+     cancelled the menu, so carrying on would wait for the boundary and then fire two
+     ENTERs into whatever the panel is showing by then. */
+  if ( setAqualinkNumericField(aqdata, "YEAR", tm_target.tm_year + 1900) != true ) {
+    LOG(ALLB_LOG, LOG_ERR, "Could not set panel year, abandoning panel time set\n");
+    goto settime_failed;
+  }
+  if ( setAqualinkNumericField(aqdata, "MONTH", tm_target.tm_mon + 1) != true ) {
+    LOG(ALLB_LOG, LOG_ERR, "Could not set panel month, abandoning panel time set\n");
+    goto settime_failed;
+  }
+  if ( setAqualinkNumericField(aqdata, "DAY", tm_target.tm_mday) != true ) {
+    LOG(ALLB_LOG, LOG_ERR, "Could not set panel day, abandoning panel time set\n");
+    goto settime_failed;
+  }
   //setAqualinkNumericFieldExtra(aqdata, "HOUR", 11, "PM");
-  /* Getting the hour wrong silently sets the panel clock wrong, so this one is neither
-     ignored nor left to select_sub_menu_item(). See setAqualinkHourField(). */
+  /* See setAqualinkHourField() for why this does not use select_sub_menu_item(). */
   if ( setAqualinkHourField(aqdata, tm_target.tm_hour) != true ) {
     LOG(ALLB_LOG, LOG_ERR, "Could not set panel hour to '%s', abandoning panel time set\n", hour);
-    cancel_menu();
-    cleanAndTerminateThread(threadCtrl);
-    return ptr;
+    goto settime_failed;
   }
   // MINUTE is the last field, so its ENTER is the one that commits.  Park the field on
   // the target minute but keep hold of that keypress.
-  setAqualinkNumericField_noenter(aqdata, "MINUTE", tm_target.tm_min);
+  if ( setAqualinkNumericField_noenter(aqdata, "MINUTE", tm_target.tm_min) != true ) {
+    LOG(ALLB_LOG, LOG_ERR, "Could not set panel minute, abandoning panel time set\n");
+    goto settime_failed;
+  }
 
   /* Remember how long that took so the next sync knows when to start.  Rise immediately
      but decay only a second per sync: a walk where every field already matched measures
@@ -1361,6 +1376,13 @@ void *set_allbutton_time( void *ptr )
   cleanAndTerminateThread(threadCtrl);
   
   // just stop compiler error, ptr is not valid as it's just been freed
+  return ptr;
+
+settime_failed:
+  /* Leave the panel out of the menu rather than parked mid-entry.  checkAqualinkTime()
+     will notice the clock is still wrong and try again on the next cycle. */
+  cancel_menu();
+  cleanAndTerminateThread(threadCtrl);
   return ptr;
 }
 

--- a/source/allbutton_aq_programmer.c
+++ b/source/allbutton_aq_programmer.c
@@ -1239,7 +1239,7 @@ void *set_allbutton_time( void *ptr )
   threadCtrl = (struct programmingThreadCtrl *) ptr;
   struct aqualinkdata *aqdata = threadCtrl->aqdata;
   
-  time_t now = time(0);   // get time now
+  time_t now;             // read after the programming slot is claimed, see below
   time_t target, walk_start;
   struct tm tm_target;
   char hour[20];
@@ -1261,11 +1261,21 @@ void *set_allbutton_time( void *ptr )
      menu means the panel is not sat in a programming menu for a minute (where it may
      time out on its own), and the programming thread is not claimed either, so anything
      else AqualinkD wants to do can still get through. */
+  /* Claim the programming slot BEFORE picking the boundary.  waitForSingleThreadOrTerminate()
+     sleeps up to 120s waiting for another programmer to finish, so choosing the target
+     first meant it could be minutes in the past by the time we got the slot - we would
+     then program a past minute, skip the boundary wait entirely and commit immediately,
+     leaving the panel behind by however long we waited. */
+  waitForSingleThreadOrTerminate(threadCtrl, AQ_SET_TIME);
+
+  now = time(0);                                     // slot acquisition may have blocked
   lead = _settime_walk_secs + AQ_SETTIME_WALK_MARGIN;
   target = ((now + lead) / 60) * 60;                 // boundary at or before now+lead
   if (target < now + lead)
     target += 60;                                    // first boundary at or after
 
+  /* Wait out here, before the menu is opened, so the panel is not sat in a programming
+     menu (where it may time out on its own) for any longer than the walk needs. */
   if (target - now > AQ_SETTIME_WALK_MARGIN) {
     LOG(ALLB_LOG, LOG_DEBUG, "Waiting %d seconds before opening SET TIME menu (last walk took %ds)\n",
         (int)(target - now - _settime_walk_secs), _settime_walk_secs);
@@ -1275,8 +1285,6 @@ void *set_allbutton_time( void *ptr )
       return ptr;
     }
   }
-
-  waitForSingleThreadOrTerminate(threadCtrl, AQ_SET_TIME);
   walk_start = time(0);
 
   localtime_r(&target, &tm_target);

--- a/source/aq_programmer.c
+++ b/source/aq_programmer.c
@@ -470,6 +470,30 @@ void _aq_programmer_(program_type r_type, aqkey *button, int value, int alt_valu
 void aq_program(program_type r_type, aqkey *button, int value, int alt_value, struct aqualinkdata *aqdata){
   _aq_programmer_(r_type, button, value, alt_value, aqdata, true);
 }
+/*
+* Does AQ_SET_TIME land on a setter that commits the panel clock on a minute boundary?
+*
+* Only set_allbutton_time() does.  The iAQ Touch and PDA setters sample the clock before
+* walking their fields and commit some seconds later, so they leave the panel tens of
+* seconds behind however tight a tolerance we hold them to - tightening the tolerance for
+* those panels just makes them re-program every hour to the same wrong time.
+*
+* MUST mirror the AQ_SET_TIME routing in aq_programmer() below.  OneTouch is deliberately
+* 'true': its AQ_SET_TIME case is commented out, so it falls through to allbutton.
+*/
+bool isPanelTimeSetterBoundaryAware()
+{
+#ifdef AQ_PDA
+  if (isPDA_PANEL && !isPDA_IAQT)
+    return false;                                    // set_PDA_aqualink_time()
+#endif
+  if (isONET_ENABLED && isEXTP_ENABLED)
+    return true;                                     // falls through to allbutton
+  if ((isIAQT_ENABLED && isEXTP_ENABLED) || isPDA_IAQT)
+    return false;                                    // set_aqualink_iaqtouch_time()
+  return true;                                       // set_allbutton_time()
+}
+
 void aq_programmer(program_type r_type, aqkey *button, int value, int alt_value, struct aqualinkdata *aqdata){
   _aq_programmer_(r_type, button, value, alt_value, aqdata, true);
 }

--- a/source/aq_programmer.h
+++ b/source/aq_programmer.h
@@ -198,6 +198,10 @@ typedef enum pump_type {
 
 //void aq_programmer(program_type type, void *args, struct aqualinkdata *aq_data);
 
+/* True when AQ_SET_TIME lands on a setter that commits on a minute boundary.
+   See the definition in aq_programmer.c - it mirrors the AQ_SET_TIME routing. */
+bool isPanelTimeSetterBoundaryAware();
+
 #ifndef NEW_AQ_PROGRAMMER
 void aq_programmer(program_type type, char *args, struct aqualinkdata *aq_data);
 #else

--- a/source/aqualink.h
+++ b/source/aqualink.h
@@ -41,6 +41,13 @@
    NOTE the old value of 120 could never detect a panel a minute out, which is why one
    stayed a minute slow indefinitely. */
 #define ACCEPTABLE_TIME_DIFF 40
+/* Tolerance for panels whose set-time path is NOT boundary aware (iAQ Touch, PDA).  Those
+   setters read the clock before walking their fields and commit seconds later, so they
+   cannot land closer than a few tens of seconds.  Holding them to the tighter figures
+   above would just make them re-program every hour to the same wrong time, so they keep
+   the original tolerance until their setters are fixed.  See
+   isPanelTimeSetterBoundaryAware(). */
+#define ACCEPTABLE_TIME_DIFF_LEGACY 120
 /* Tolerance used when the offset was timed from the panel's minute rollover instead of
    read off its HH:MM display.  That measurement is good to about +/-(gap/2), ~4s on an
    RS panel whose display cycles every 8s, so it can be held to a much tighter figure.

--- a/source/aqualink.h
+++ b/source/aqualink.h
@@ -26,7 +26,43 @@
 
 #define TIME_CHECK_INTERVAL  3600
 //#define TIME_CHECK_INTERVAL  100 // DEBUG ONLY
-#define ACCEPTABLE_TIME_DIFF 120
+/* How far the panel clock may be out before we re-set it.
+
+   This cannot usefully go below ~35.  The panel reports HH:MM with no seconds, so its
+   clock is estimated as the midpoint of the minute it is displaying, which means every
+   measurement carries +/-30s of quantisation noise even when the panel is perfect:
+
+       measured diff = -offset + (s - 30),   s = panel seconds-into-minute, 0..59
+
+   At 30 or below a perfectly synced panel would resync itself forever.  40 leaves ~10s
+   of headroom for that noise plus the latency between the panel rendering its display
+   and us parsing the message.  Panel crystal drift is ~0.2s/hour so real drift between
+   hourly checks is negligible; what this needs to catch is a panel that lost power.
+   NOTE the old value of 120 could never detect a panel a minute out, which is why one
+   stayed a minute slow indefinitely. */
+#define ACCEPTABLE_TIME_DIFF 40
+/* Tolerance used when the offset was timed from the panel's minute rollover instead of
+   read off its HH:MM display.  That measurement is good to about +/-(gap/2), ~4s on an
+   RS panel whose display cycles every 8s, so it can be held to a much tighter figure.
+   See the rollover block in aqualinkd.c. */
+#define ACCEPTABLE_TIME_DIFF_PRECISE 15
+/* Reject a rollover seen across a gap wider than this.  Beyond ~30s the estimate is no
+   better than the HH:MM midpoint it would replace, so there is nothing to gain.
+   Do NOT set this near the panel's display cycle: it is not a quality cutoff, the
+   tolerance is scaled by the measured window instead (see AQ_ROLLOVER_SLACK).  An RS
+   panel cycles every 8s, alternating to 10s, and stretches past 13s whenever
+   programming perturbs the display - a tight limit here just throws away good data. */
+#define AQ_ROLLOVER_MAX_WINDOW 30
+/* Added to a rollover's own +/- uncertainty to get the tolerance used against it, so a
+   loosely pinned rollover degrades gracefully instead of being discarded. */
+#define AQ_ROLLOVER_SLACK 8
+/* ...and reject one this old, so we never judge on a stale observation. A rollover
+   happens every minute, so a good one is normally well under this. */
+#define AQ_ROLLOVER_MAX_AGE 75
+/* How long after startup the forced panel time sync waits before it runs.  Setting the
+   panel clock takes over the panel's menus, so doing it during init stalls everything
+   else AqualinkD is trying to read.  Let startup finish, then sync in the background. */
+#define AQ_STARTUP_TIME_SYNC_DELAY 60
 
 
 #define MAX_ZERO_READ_BEFORE_RECONNECT 10

--- a/source/aqualinkd.c
+++ b/source/aqualinkd.c
@@ -381,22 +381,32 @@ bool checkAqualinkTime()
   /* Prefer the rollover timed offset when we have a usable one.  It is roughly an
      order of magnitude tighter than reading HH:MM and assuming the midpoint, so it
      is judged against a correspondingly tighter tolerance. */
-  int tolerance = ACCEPTABLE_TIME_DIFF;
+  /* How close the panel can actually be held depends on which setter AQ_SET_TIME lands
+     on.  Only the allbutton one commits on a minute boundary; the iAQ Touch and PDA
+     setters cannot land closer than a few tens of seconds, so tightening the tolerance
+     for them would just re-program the panel every hour to the same wrong time. */
+  bool boundary_aware = isPanelTimeSetterBoundaryAware();
+  int tolerance = boundary_aware ? ACCEPTABLE_TIME_DIFF : ACCEPTABLE_TIME_DIFF_LEGACY;
   int precise, accuracy;
   if (panel_rollover_offset(now, &precise, &accuracy))
   {
-    /* Only act on an offset bigger than what we can actually resolve.  Scaling by the
-       measured window rather than applying a fixed cutoff means a rollover we only
-       pinned loosely still gets used, just held to a looser figure - and it is never
-       worse than the coarse path it replaces. */
-    tolerance = accuracy + AQ_ROLLOVER_SLACK;
-    if (tolerance < ACCEPTABLE_TIME_DIFF_PRECISE)
-      tolerance = ACCEPTABLE_TIME_DIFF_PRECISE;
-    if (tolerance > ACCEPTABLE_TIME_DIFF)
-      tolerance = ACCEPTABLE_TIME_DIFF;
+    /* The rollover measurement is good regardless of which setter we use, so always
+       prefer it for the figure we report and act on.  Only the TOLERANCE depends on what
+       the setter can achieve. */
+    time_difference = precise;
+    if (boundary_aware) {
+      /* Only act on an offset bigger than what we can actually resolve.  Scaling by the
+         measured window rather than applying a fixed cutoff means a rollover we only
+         pinned loosely still gets used, just held to a looser figure - and it is never
+         worse than the coarse path it replaces. */
+      tolerance = accuracy + AQ_ROLLOVER_SLACK;
+      if (tolerance < ACCEPTABLE_TIME_DIFF_PRECISE)
+        tolerance = ACCEPTABLE_TIME_DIFF_PRECISE;
+      if (tolerance > ACCEPTABLE_TIME_DIFF)
+        tolerance = ACCEPTABLE_TIME_DIFF;
+    }
     LOG(AQUA_LOG,LOG_INFO, "Panel clock is %+d seconds off system time (+/-%ds, timed from the panel's minute rollover over %ds), tolerance %ds\n",
         precise, accuracy, _ro_window, tolerance);
-    time_difference = precise;
   }
 
   if (force_due)

--- a/source/aqualinkd.c
+++ b/source/aqualinkd.c
@@ -110,6 +110,14 @@ void main_loop();
 int startup(char *self, char *cfgFile);
 
 
+/* One shot, armed in startup() when force_panel_time_sync_at_startup is set.  Holds the
+   time the forced sync becomes due (0 = not armed).  Makes that one comparison report the
+   panel as wrong even when it is inside ACCEPTABLE_TIME_DIFF, so the panel clock gets
+   rewritten once per daemon start.  Deliberately NOT due immediately: setting the clock
+   takes over the panel menus for a while, which is the last thing we want while startup
+   is still collecting state. */
+static time_t _force_panel_time_sync_after = 0;
+
 bool isAqualinkDStopping() {
   return !_keepRunning;
 }
@@ -157,6 +165,108 @@ bool isVirtualButtonEnabled() {
 }
 
 
+/* --------------------------------------------------------------------------
+ * Panel minute rollover timing.
+ *
+ * The panel reports HH:MM with no seconds, so one reading only locates its clock
+ * to within a minute; we assume the midpoint, which is +/-30s of noise however
+ * accurate the panel actually is.  But the panel repeats its display every few
+ * seconds, so the moment the displayed minute CHANGES pins the panel's HH:MM:00
+ * to within one message gap - about 8s on an RS panel, so +/-4s once we take the
+ * middle of the gap.  That is tight enough to judge against
+ * ACCEPTABLE_TIME_DIFF_PRECISE instead of ACCEPTABLE_TIME_DIFF.
+ *
+ * Only used where the panel reports a real date.  PDA reports a weekday and its
+ * check has its own day-of-week handling, so that path keeps the coarse estimate.
+ * -------------------------------------------------------------------------- */
+static char   _ro_last_time[AQ_MSGLEN] = "";
+static time_t _ro_prev_sample = 0;   /* when the previous time message arrived */
+static time_t _ro_at          = 0;   /* when we first saw the new minute */
+static int    _ro_window      = 0;   /* gap between those two messages */
+static time_t _ro_panel_min   = 0;   /* when that minute SHOULD have started */
+
+/* Parse the panel's 'MM/DD/YY' + 'H:MM XM' into the time_t its minute started. */
+static bool panel_minute_start(time_t now, time_t *out)
+{
+  char datestr[DATE_STRING_LEN];
+  struct tm tm;
+  size_t dlen = strlen(_aqualink_data.date);
+  size_t tlen = strlen(_aqualink_data.time);
+
+  /* 'MM/DD/YY' is 8, 'H:MM XM' is 7 and 'HH:MM XM' is 8. Anything else is not
+     something the surgery below can lay out, and would risk overrunning datestr. */
+  if (dlen < 8 || dlen > 12 || tlen < 7 || tlen > 8)
+    return false;
+
+  memset(&tm, 0, sizeof(tm));
+  memcpy(&datestr[0], _aqualink_data.date, 8);
+  datestr[8] = ' ';
+  memcpy(&datestr[9], _aqualink_data.time, tlen);
+  datestr[9 + tlen] = '\0';
+
+  if (strptime(datestr, "%m/%d/%y %I:%M %p", &tm) == NULL)
+    return false;
+
+  tm.tm_sec = 0;                                   /* the START of the minute */
+  tm.tm_isdst = localtime(&now)->tm_isdst;
+  *out = mktime(&tm);
+  return true;
+}
+
+/* Called for every panel time message, before any of the rate limiting below. */
+static void observe_panel_rollover(time_t now)
+{
+  time_t minstart;
+
+#ifdef AQ_PDA
+  if (isPDA_PANEL && !isPDA_IAQT)
+    return;
+#endif
+
+  if (strncmp(_aqualink_data.time, _ro_last_time, sizeof(_ro_last_time)) != 0) {
+    /* Displayed minute just changed, so its :00 fell between the previous message
+       and this one.  _ro_prev_sample of 0 means this is our first message and we
+       have no window to measure, so only remember the string. */
+    if (_ro_prev_sample != 0 && panel_minute_start(now, &minstart)) {
+      _ro_at        = now;
+      _ro_window    = (int)(now - _ro_prev_sample);
+      _ro_panel_min = minstart;
+      LOG(AQUA_LOG,LOG_DEBUG, "Panel minute rolled to '%s' %ds after the previous message\n",
+          _aqualink_data.time, _ro_window);
+    }
+    strncpy(_ro_last_time, _aqualink_data.time, sizeof(_ro_last_time) - 1);
+    _ro_last_time[sizeof(_ro_last_time) - 1] = '\0';
+  }
+  _ro_prev_sample = now;
+}
+
+/* Offset in seconds, positive meaning the panel clock is BEHIND system time -
+   the same sense as the coarse difftime() comparison. */
+static bool panel_rollover_offset(time_t now, int *offset, int *accuracy)
+{
+  /* These report at INFO rather than DEBUG on purpose: when the rollover estimate is
+     not used, the reason for falling back to the coarse +/-30s figure needs to be
+     visible in a normal log. */
+  if (_ro_at == 0 || _ro_window <= 0) {
+    LOG(AQUA_LOG,LOG_INFO, "No panel minute rollover timed yet, using the +/-30s HH:MM estimate\n");
+    return false;
+  }
+  if (_ro_window > AQ_ROLLOVER_MAX_WINDOW) {
+    LOG(AQUA_LOG,LOG_INFO, "Panel minute rollover only pinned to %ds, no better than the HH:MM estimate, using that\n",
+        _ro_window);
+    return false;
+  }
+  if (now - _ro_at > AQ_ROLLOVER_MAX_AGE) {
+    LOG(AQUA_LOG,LOG_INFO, "Last panel minute rollover is %ds old, using the +/-30s HH:MM estimate\n",
+        (int)(now - _ro_at));
+    return false;
+  }
+
+  *offset   = (int)((_ro_at - (_ro_window / 2)) - _ro_panel_min);
+  *accuracy = (_ro_window / 2) + 1;
+  return true;
+}
+
 // Should move to panel.
 bool checkAqualinkTime()
 {
@@ -169,8 +279,15 @@ bool checkAqualinkTime()
   if (_aqconfig_.sync_panel_time != true)
     return true; 
 
+  // Must run on EVERY time message, so it goes before all the rate limiting below.
+  observe_panel_rollover(now);
+
+  // A due forced sync has to skip the hourly rate limit, otherwise arming it at startup
+  // would not take effect until the next scheduled check up to an hour later.
+  bool force_due = (_force_panel_time_sync_after != 0 && now >= _force_panel_time_sync_after);
+
   time_difference = (int)difftime(now, last_checked);
-  if (time_difference < TIME_CHECK_INTERVAL)
+  if (!force_due && time_difference < TIME_CHECK_INTERVAL)
   {
     LOG(AQUA_LOG,LOG_DEBUG, "time not checked, will check in %d seconds\n", TIME_CHECK_INTERVAL - time_difference);
     return true;
@@ -233,7 +350,14 @@ bool checkAqualinkTime()
   }
 
   aq_tm.tm_isdst = localtime(&now)->tm_isdst; // ( Might need to use -1) set daylight savings to same as system time
-  aq_tm.tm_sec = 0; // Set seconds to time.  Really messes up when we don't do this.
+  // The panel only reports HH:MM, it has no seconds field.  A panel showing '10:05'
+  // is actually somewhere in 10:05:00 - 10:05:59, so the best estimate of the panel
+  // clock is the MIDPOINT of the minute it is displaying.  Using 0 here made every
+  // comparison read 0-59 seconds slow (+30 on average) even for a perfectly synced
+  // panel, which both hid real drift and made the panel look ~1 minute behind.
+  // NOTE: seconds must be set to something deterministic, strptime() leaves whatever
+  // was on the stack in tm_sec.
+  aq_tm.tm_sec = 30;
 
   char buff[30];
   
@@ -254,10 +378,41 @@ bool checkAqualinkTime()
   strftime(buff, 30, "%m/%d/%y %I:%M %p", localtime(&now));
   LOG(AQUA_LOG,LOG_INFO, "Aqualink time '%s' is off system time '%s' by %d seconds...\n", datestr, buff, time_difference);
 
-  if (abs(time_difference) < ACCEPTABLE_TIME_DIFF)
+  /* Prefer the rollover timed offset when we have a usable one.  It is roughly an
+     order of magnitude tighter than reading HH:MM and assuming the midpoint, so it
+     is judged against a correspondingly tighter tolerance. */
+  int tolerance = ACCEPTABLE_TIME_DIFF;
+  int precise, accuracy;
+  if (panel_rollover_offset(now, &precise, &accuracy))
   {
-    // Time difference is less than or equal to ACCEPTABLE_TIME_DIFF seconds (1 1/2 minutes).
-    // Set the return value to true.
+    /* Only act on an offset bigger than what we can actually resolve.  Scaling by the
+       measured window rather than applying a fixed cutoff means a rollover we only
+       pinned loosely still gets used, just held to a looser figure - and it is never
+       worse than the coarse path it replaces. */
+    tolerance = accuracy + AQ_ROLLOVER_SLACK;
+    if (tolerance < ACCEPTABLE_TIME_DIFF_PRECISE)
+      tolerance = ACCEPTABLE_TIME_DIFF_PRECISE;
+    if (tolerance > ACCEPTABLE_TIME_DIFF)
+      tolerance = ACCEPTABLE_TIME_DIFF;
+    LOG(AQUA_LOG,LOG_INFO, "Panel clock is %+d seconds off system time (+/-%ds, timed from the panel's minute rollover over %ds), tolerance %ds\n",
+        precise, accuracy, _ro_window, tolerance);
+    time_difference = precise;
+  }
+
+  if (force_due)
+  {
+    // Startup sync was requested and is now due.  Consumed here rather than in startup()
+    // so we inherit every check above, the panel has to be initialised and have actually
+    // told us its time before we start walking its menus.
+    _force_panel_time_sync_after = 0;
+    LOG(AQUA_LOG,LOG_NOTICE, "Forcing panel time sync (%s=yes), panel is off by %d seconds\n",
+        CFG_N_force_panel_time_sync_at_startup, time_difference);
+    return false;
+  }
+
+  if (abs(time_difference) < tolerance)
+  {
+    // Within tolerance, leave the panel alone.
     return true;
   }
 
@@ -630,7 +785,19 @@ int startup(char *self, char *cfgFile)
     _aqconfig_.log_msec_ts = true;
 
   setMsecTimestampLog(_aqconfig_.log_msec_ts);
-      
+
+  // Arm the one shot startup time sync, due AQ_STARTUP_TIME_SYNC_DELAY from now so it
+  // runs in the background once startup has settled rather than stalling it.  Done here
+  // (rather than at the declaration) so a self restart, which calls startup() again,
+  // re-arms it.
+  if (_aqconfig_.sync_panel_time && _aqconfig_.force_panel_time_sync_at_startup) {
+    _force_panel_time_sync_after = time(0) + AQ_STARTUP_TIME_SYNC_DELAY;
+    LOG(AQUA_LOG,LOG_NOTICE, "Panel time will be synced in %d seconds (%s=yes)\n",
+        AQ_STARTUP_TIME_SYNC_DELAY, CFG_N_force_panel_time_sync_at_startup);
+  } else {
+    _force_panel_time_sync_after = 0;
+  }
+
 
 #ifdef AQ_MANAGER
   setLoggingPrms(_aqconfig_.log_level, _aqconfig_.deamonize, (_aqconfig_.display_warnings_web?_aqualink_data.last_display_message:NULL));

--- a/source/config.c
+++ b/source/config.c
@@ -611,6 +611,16 @@ void init_parameters (struct aqconfig * parms)
   _cfgParams[_numCfgParams].default_value = (void *)&_dcfg_true;
 
   _numCfgParams++;
+  _cfgParams[_numCfgParams].value_ptr = &_aqconfig_.force_panel_time_sync_at_startup;
+  _cfgParams[_numCfgParams].value_type = CFG_BOOL;
+  _cfgParams[_numCfgParams].name = CFG_N_force_panel_time_sync_at_startup;
+  // No CFG_GRP_ADVANCED: sync_panel_time above is visible by default and this is its
+  // companion, hiding one behind the 'show advanced' toggle splits the pair.
+  // Note this option is only read once, when startup() arms the one shot, so a change
+  // here does not take effect until AqualinkD is restarted.
+  _cfgParams[_numCfgParams].default_value = (void *)&_dcfg_false;
+
+  _numCfgParams++;
   _cfgParams[_numCfgParams].value_ptr = &_aqconfig_.display_warnings_web;
   _cfgParams[_numCfgParams].value_type = CFG_BOOL;
   _cfgParams[_numCfgParams].name = "display_warnings_in_web";

--- a/source/config.h
+++ b/source/config.h
@@ -122,6 +122,7 @@ struct aqconfig
 
   bool mqtt_timed_update;
   bool sync_panel_time;
+  bool force_panel_time_sync_at_startup;
   bool enable_scheduler;
   int8_t schedule_event_mask; // Was int16_t, but no need
   int  sched_chk_pumpon_hour;
@@ -280,6 +281,10 @@ int _numCfgParams;
 #define CFG_V_extended_device_id                "[\"0x00\", \"0x30\", \"0x31\", \"0x32\", \"0x33\", \"0x40\", \"0x41\", \"0x42\", \"0x43\"]"
 
 #define CFG_N_sync_panel_time                   "sync_panel_time"
+/* NOTE: setConfigValue() matches config names by PREFIX, first registered wins, so this
+   deliberately does NOT start with "sync_panel_time" - a name like
+   "sync_panel_time_on_startup" would be swallowed by "sync_panel_time" above. */
+#define CFG_N_force_panel_time_sync_at_startup  "force_panel_time_sync_at_startup"
 
 #define CFG_N_extended_device_id_programming    "extended_device_id_programming"
 #define CFG_N_enable_iaqualink                  "enable_iaqualink"

--- a/web/aqmanager.html
+++ b/web/aqmanager.html
@@ -1418,6 +1418,10 @@
       // More advanced groupings
       if(obj.toString().includes("device_id") && lastKey.includes("device_id")) {
         hideLineSeperator = true;
+      } else if(obj.toString().includes("panel_time") && lastKey.includes("panel_time")) {
+        // sync_panel_time and force_panel_time_sync_at_startup belong together, but the
+        // first letter grouping above cannot see that ('s' then 'f').
+        hideLineSeperator = true;
       } else if(obj.toString().includes("light_program_")) {
         hideLineSeperator = true;
         if(obj.toString().includes("light_program_01")) {


### PR DESCRIPTION
`sync_panel_time` leaves the panel clock about a minute slow, and never corrects it. Tested on an RS8 (`6520 REV HH`).

## Why

**The commit instant decides the accuracy.** The panel has no seconds field — it starts its clock at `HH:MM:00` the moment the entry is committed. `set_allbutton_time()` read the clock up front and added a fixed 30s, so the panel ended up behind by however long the menu walk took. Every digit is a keypress that round-trips through the panel display (~0.26s), and the MINUTE field can be up to 59 of them.

**The measurement was biased the same way.** `checkAqualinkTime()` parsed the panel's `HH:MM` as `HH:MM:00`, when it actually means "somewhere in that minute". Every comparison read 0–59s slow (+30 average) even for a perfect panel.

**And it could never self-correct.** `ACCEPTABLE_TIME_DIFF` was 120s, so a panel a minute out was always "close enough". That's why one stays a minute slow indefinitely.

## What changed

**Commit on a minute boundary.** Pick the boundary, wait for it *outside* the menu, then walk the fields so the commit lands on it. Waiting outside means the panel isn't held in a programming menu for a minute (where it may time out), and the programming thread isn't claimed either. The walk duration is measured and remembered to decide when to start the next one.

Measured on an RS8 — three consecutive syncs committed **35ms, 61ms and 87ms** after the target.

**Time the panel's minute rollover instead of reading `HH:MM`.** The panel repeats its display every ~8s, so the moment the shown minute *changes* pins its clock to within half a message gap — about ±4s, versus ±30s. That lets the tolerance drop to **15s**, scaled up when the rollover is only loosely pinned, and falling back to the old estimate when none is usable.

Verified against a panel provably within 35ms of correct, so the readings measure the estimator's own error: spread −5..+3s over nine minutes, every value inside the ±5s it reports.

**Fix the hour being set an hour fast.** `select_sub_menu_item()` waits only for the final target string. Coming out of the DAY field the last message received is still the DAY line, so it pressed RIGHT before it had ever seen the hour, then matched the pre-keypress `HOUR n xM` the panel had already queued — committing an hour too far. The result was also ignored, so it failed silently.

Replaced with `setAqualinkHourField()`, which waits for the value each keypress *should* produce — the same technique `setAqualinkNumericField()` already uses, and immune to the race. Tested across all 24×24 start/target hour combinations with a stale message present.

## New config option

`force_panel_time_sync_at_startup` (default `no`) syncs once per start even when the panel is inside tolerance — useful if your panel loses time when power cycled. Deferred 60s so it doesn't stall startup, and skips the hourly rate limit so arming it actually takes effect.

## Not covered

- **`iaqtouch`, `onetouch` and PDA set-time paths** have the same missing-elapsed-time bug and no `+30` compensation at all, so they remain ~30s plus programming time slow. I have no hardware to test them on, so I left them alone rather than guess.
- **`select_sub_menu_item()`'s race is untouched.** Its other callers are menu *navigation* rather than value setting, where a stray keypress is far less damaging. Fixing it properly would mean re-verifying every caller.
- **The rollover estimator has a ±4s sawtooth**, because the ~8s cadence beats against the 60s minute. Averaging several rollovers would remove it and allow a tighter tolerance, but 15s already catches anything real.

Rebased onto current `master`; builds clean with no new warnings.
