### PR TITLE
iAQ Touch: fix device page 3 unreachable/stuck-loop bugs

### DIFF
--- a/source/iaqtouch.c
+++ b/source/iaqtouch.c
@@ -1108,7 +1108,7 @@ if not programming && poll packet {
               nextPageRequestKey = KEY_IAQTCH_STATUS;
           break;
           case IAQ_PAGE_DEVICES3:
-            if (_devicePageButtons[1][16].type == 0x03) 
+            if (_devicePageButtons[2][16].type == 0x03)
               nextPageRequestKey = KEY_IAQTCH_NEXT_PAGE;
             else
               nextPageRequestKey = KEY_IAQTCH_STATUS;
@@ -1208,7 +1208,7 @@ const char *iaqt_page_name(const unsigned char page)
       return "Devices #2";
     break;
     case IAQ_PAGE_DEVICES3:
-      return "Devices #2";
+      return "Devices #3";
     break;
     case IAQ_PAGE_SET_TEMP:
       return "Set Temp";

--- a/source/iaqtouch_aq_programmer.c
+++ b/source/iaqtouch_aq_programmer.c
@@ -532,11 +532,12 @@ void *set_aqualink_iaqtouch_device_on_off( void *ptr )
       pButton = iaqtFindButtonByLabel(((altlabel_detail *)button->special_mask_ptr)->altlabel);
     }
  
-  // If not found see if page has next
-    if (pButton == NULL && iaqtFindButtonByIndex(16)->type == 0x03 ) {
+  // If not found, keep advancing through further device pages while each one says it has more.
+  // Bounded to match _devicePageButtons' 3 known pages (this page + 2 more), so a
+  // misbehaving/wrapping page sequence can't spin this loop forever.
+    for (int _devPage = 0; pButton == NULL && _devPage < 2 && iaqtFindButtonByIndex(16)->type == 0x03; _devPage++) {
       iaqt_queue_cmd(KEY_IAQTCH_NEXT_PAGE);
       waitfor_iaqt_nextPage(aqdata);
-    // This will fail, since not looking at device page 2 buttons
       pButton = iaqtFindButtonByLabel(button->label);
     }
   }
@@ -612,16 +613,17 @@ void *set_aqualink_iaqtouch_device_on_off( void *ptr )
       button = iaqtFindButtonByLabel(((altlabel_detail *)aqdata->aqbuttons[device].special_mask_ptr)->altlabel);
     }
  
-  // If not found see if page has next
-    if (button == NULL && iaqtFindButtonByIndex(16)->type == 0x03 ) {
+  // If not found, keep advancing through further device pages while each one says it has more.
+  // Bounded to match _devicePageButtons' 3 known pages (this page + 2 more), so a
+  // misbehaving/wrapping page sequence can't spin this loop forever.
+    for (int _devPage = 0; button == NULL && _devPage < 2 && iaqtFindButtonByIndex(16)->type == 0x03; _devPage++) {
       iaqt_queue_cmd(KEY_IAQTCH_NEXT_PAGE);
       waitfor_iaqt_nextPage(aqdata);
-    // This will fail, since not looking at device page 2 buttons
       button = iaqtFindButtonByLabel(aqdata->aqbuttons[device].label);
     }
   }
 
-  if (button == NULL) {  
+  if (button == NULL) {
     LOG(IAQT_LOG, LOG_ERR, "IAQ Touch did not find '%s' button on device list\n", aqdata->aqbuttons[device].label);
     goto f_end;
   }
@@ -781,11 +783,12 @@ void *set_aqualink_iaqtouch_light_colormode( void *ptr )
     pButton = iaqtFindButtonByLabel(key->label);
  
 //DPRINTF("Second button find = %s\n",pButton==NULL?"null":pButton->name);
-  // If not found see if page has next
-    if (pButton == NULL && iaqtFindButtonByIndex(16)->type == 0x03 ) {
+  // If not found, keep advancing through further device pages while each one says it has more.
+  // Bounded to match _devicePageButtons' 3 known pages (this page + 2 more), so a
+  // misbehaving/wrapping page sequence can't spin this loop forever.
+    for (int _devPage = 0; pButton == NULL && _devPage < 2 && iaqtFindButtonByIndex(16)->type == 0x03; _devPage++) {
       iaqt_queue_cmd(KEY_IAQTCH_NEXT_PAGE);
       waitfor_iaqt_nextPage(aqdata);
-    // This will fail, since not looking at device page 2 buttons
       pButton = iaqtFindButtonByLabel(key->label);
 //DPRINTF("Third button find = %s\n",pButton==NULL?"null":pButton->name);
     }


### PR DESCRIPTION
## Summary

Two related bugs in the iAQ Touch device-page-walking logic, both hit while raising `VIRTUAL_BUTTONS` (see discussion #533) to expose Remote Power Center circuits beyond the original 6-8 virtual button slots. Once total buttons push the device listing onto its 3rd page, both bugs prevent that page from being usable at all.

## Bug 1 — idle poll loop can get stuck repeating on page 3

`iaqtouch.c`'s poll-loop "does this page have more?" check compared `_devicePageButtons[1][16].type` (page 2's own flag) for **both** the `IAQ_PAGE_DEVICES2` and `IAQ_PAGE_DEVICES3` cases — a copy/paste miss. Every other place in the file that maps `IAQ_PAGE_DEVICES3` to an array index correctly uses `[2]` (see `getCurrentPageButtons`, `getCurrentPageButtonAt`, the debug-page helpers).

Symptom, reproduced live: once enough buttons are configured to reach page 3, the daemon can get stuck spinning and log this repeatedly (~every 65s) until restarted:
```
iAQ Touch: Poll count=205, too high, looks like page is stuck
```
Not fatal — AllButton-protocol equipment/heater/freeze-protect control kept working throughout — but a real, repeating malfunction on a system that also controls pool/spa heaters.

Also fixes an adjacent cosmetic bug where `IAQ_PAGE_DEVICES3`'s debug page-name string returned `"Devices #2"` (same as `DEVICES2`), making debug logs ambiguous about which page was actually active.

## Bug 2 — a button living on page 3 could never be found or set, independent of bug 1

Separately, the button-*search* logic used when actually setting a device (`set_aqualink_iaqtouch_device_on_off`, both the active and the `NEW_AQ_PROGRAMMER` variant, and `set_aqualink_iaqtouch_light_colormode`) was hardcoded to try the first device page, then advance to a **second** page if the first said there was more, then give up unconditionally — even if that second page's own flag also said there was more. The code had a comment admitting the gap:
```c
// This will fail, since not looking at device page 2 buttons
```
This is independent of how many `virtual_button_XX` entries are configured — it's about where the target button's real position lands on the panel's own page layout. Any real circuit on page 3 was unreachable for read/write regardless of config.

Turned each single retry into a loop, bounded at 2 further page-advances (matching `_devicePageButtons`' 3 known page slots, so a misbehaving/wrapping page sequence can't spin forever):
```c
for (int _devPage = 0; button == NULL && _devPage < 2 && iaqtFindButtonByIndex(16)->type == 0x03; _devPage++) {
  iaqt_queue_cmd(KEY_IAQTCH_NEXT_PAGE);
  waitfor_iaqt_nextPage(aqdata);
  button = iaqtFindButtonByLabel(aqdata->aqbuttons[device].label);
}
```

## Testing

Both reproduced and fixed live against a real RS-16 Combo panel with Remote Power Center circuits on device page 3 (`VIRTUAL_BUTTONS` raised locally to test):
- With only bug 1 fixed, a button whose real position was on page 3 still failed every attempt (clean, non-repeating `did not find` — bug 1's fix stops the daemon malfunctioning, it doesn't make page-3 buttons reachable on its own).
- With bug 2 also fixed, the same button was found and set successfully on the first try.
- Ran an extended multi-button test session afterward (6 buttons on/off, several landing on page 2 and page 3) with zero stuck-page recurrence in the logs.